### PR TITLE
issue #92 has been resolved.

### DIFF
--- a/AzureKeyVaultEmulator.IntegrationTests/Extensions/Assert/SharedAsserts.cs
+++ b/AzureKeyVaultEmulator.IntegrationTests/Extensions/Assert/SharedAsserts.cs
@@ -16,4 +16,6 @@ public partial class Assert
 
         Equal((int)HttpStatusCode.BadRequest, exception?.Status);
     }
+
+  
 }

--- a/AzureKeyVaultEmulator.IntegrationTests/Keys/KeysControllerTests.cs
+++ b/AzureKeyVaultEmulator.IntegrationTests/Keys/KeysControllerTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Security.Cryptography;
-using Azure;
 using Azure.Security.KeyVault.Keys;
 using Azure.Security.KeyVault.Keys.Cryptography;
 using AzureKeyVaultEmulator.IntegrationTests.SetupHelper;
@@ -48,9 +47,7 @@ public sealed class KeysControllerTests(KeysTestingFixture fixture) : IClassFixt
 
         var keyName = fixture.FreshlyGeneratedGuid;
 
-        var exception = await Assert.ThrowsAsync<RequestFailedException>(() => client.GetKeyAsync(keyName));
-
-        Assert.Equal((int)HttpStatusCode.BadRequest, exception.Status);
+        await Assert.RequestFailsAsync(() => client.GetKeyAsync(keyName));
     }
 
     [Fact]
@@ -219,10 +216,7 @@ public sealed class KeysControllerTests(KeysTestingFixture fixture) : IClassFixt
 
         var key = await fixture.CreateKeyAsync(keyName);
 
-        var exception = await Assert
-            .ThrowsAsync<RequestFailedException>(() => client.GetKeyRotationPolicyAsync(keyName));
-
-        Assert.Equal((int)HttpStatusCode.BadRequest, exception.Status);
+        await Assert.RequestFailsAsync(() => client.GetKeyRotationPolicyAsync(keyName));
 
         var policy = new KeyRotationPolicy
         {

--- a/AzureKeyVaultEmulator.IntegrationTests/Secrets/DeletedSecretsControllerTests.cs
+++ b/AzureKeyVaultEmulator.IntegrationTests/Secrets/DeletedSecretsControllerTests.cs
@@ -1,5 +1,4 @@
-﻿using Azure;
-using Azure.Security.KeyVault.Secrets;
+﻿using Azure.Security.KeyVault.Secrets;
 using AzureKeyVaultEmulator.IntegrationTests.SetupHelper;
 using AzureKeyVaultEmulator.IntegrationTests.SetupHelper.Fixtures;
 
@@ -21,10 +20,8 @@ namespace AzureKeyVaultEmulator.IntegrationTests.Secrets
 
             Assert.Equal(secret.Name, deletedAction.Value.Name);
 
-            var shouldFail = await Assert.ThrowsAsync<RequestFailedException>(() => client.GetSecretAsync(secret.Name));
-
-            Assert.Equal((int)HttpStatusCode.BadRequest, shouldFail.Status);
-
+            await Assert.RequestFailsAsync(() => client.GetSecretAsync(secret.Name));
+           
             var fromDeletedSource = await client.GetDeletedSecretAsync(secret.Name);
 
             Assert.Equal(secret.Name, fromDeletedSource.Value.Name);
@@ -77,11 +74,9 @@ namespace AzureKeyVaultEmulator.IntegrationTests.Secrets
 
             await client.PurgeDeletedSecretAsync(secretName);
 
-            var deletedEndpointResult = await Assert.ThrowsAsync<RequestFailedException>(() => client.GetDeletedSecretAsync(secretName));
-            var baseEndpointResult = await Assert.ThrowsAsync<RequestFailedException>(() => client.GetSecretAsync(secretName));
+            await Assert.RequestFailsAsync(() => client.GetDeletedSecretAsync(secretName));
 
-            Assert.Equal((int)HttpStatusCode.BadRequest, deletedEndpointResult.Status);
-            Assert.Equal((int)HttpStatusCode.BadRequest, baseEndpointResult.Status);
+            await Assert.RequestFailsAsync(() => client.GetSecretAsync(secretName));
         }
 
         [Fact]
@@ -108,9 +103,8 @@ namespace AzureKeyVaultEmulator.IntegrationTests.Secrets
 
             Assert.Equal(secretName, afterRecovery.Value.Name);
 
-            var deletedResult = await Assert.ThrowsAsync<RequestFailedException>(() => client.GetDeletedSecretAsync(secretName));
+            await Assert.RequestFailsAsync(() => client.GetDeletedSecretAsync(secretName));
 
-            Assert.Equal((int)HttpStatusCode.BadRequest, deletedResult.Status);
         }
     }
 }

--- a/AzureKeyVaultEmulator.IntegrationTests/Secrets/SecretsControllerTests.cs
+++ b/AzureKeyVaultEmulator.IntegrationTests/Secrets/SecretsControllerTests.cs
@@ -1,5 +1,4 @@
-﻿using Azure;
-using Azure.Security.KeyVault.Secrets;
+﻿using Azure.Security.KeyVault.Secrets;
 using AzureKeyVaultEmulator.IntegrationTests.SetupHelper;
 using AzureKeyVaultEmulator.IntegrationTests.SetupHelper.Fixtures;
 
@@ -53,9 +52,8 @@ namespace AzureKeyVaultEmulator.IntegrationTests.Secrets
             Assert.NotNull(deletedSecret.Value);
             Assert.Equal(deletedName, deletedSecret.Value.Name);
 
-            var gottenAfterDeleted = await Assert.ThrowsAsync<RequestFailedException>(() => client.GetSecretAsync(deletedName));
+            await Assert.RequestFailsAsync(() => client.GetSecretAsync(deletedName));
 
-            Assert.Equal((int)HttpStatusCode.BadRequest, gottenAfterDeleted.Status);
         }
 
         [Fact]
@@ -164,9 +162,7 @@ namespace AzureKeyVaultEmulator.IntegrationTests.Secrets
 
             Assert.Equal(deletedOperation.Value.Value, secret.Value);
 
-            var result = await Assert.ThrowsAsync<RequestFailedException>(() => client.GetSecretAsync(secret.Name));
-
-            Assert.Equal((int)HttpStatusCode.BadRequest, result.Status);
+            await Assert.RequestFailsAsync(() => client.GetSecretAsync(secret.Name));
         }
     }
 }


### PR DESCRIPTION
### Summary

This PR is to expand the ThrowsRequestFailedAsync(RequestFailsAsync) extension using.
In the code there was already an implementation for ThrowsRequestFailedAsync as RequestFailsAsync. I didn't change the name and used as it was.

### Related Issue

Fixes #92 

### Changes

- RequestFailsAsync extension method were used.

### Checklist

- [x] Code compiles
- [x] Tests pass
- [x] No breaking changes introduced