### PR TITLE
SecretService fixed to access correct stores based on context

### DIFF
--- a/AzureKeyVaultEmulator.IntegrationTests/Extensions/Assert/SharedAsserts.cs
+++ b/AzureKeyVaultEmulator.IntegrationTests/Extensions/Assert/SharedAsserts.cs
@@ -16,6 +16,4 @@ public partial class Assert
 
         Equal((int)HttpStatusCode.BadRequest, exception?.Status);
     }
-
-  
 }

--- a/AzureKeyVaultEmulator/Emulator/Services/EncryptionService.cs
+++ b/AzureKeyVaultEmulator/Emulator/Services/EncryptionService.cs
@@ -5,7 +5,7 @@ namespace AzureKeyVaultEmulator.Emulator.Services
     public interface IEncryptionService : IDisposable
     {
         string CreateKeyVaultJwe(object value);
-        T DecryptFromKeyVaultJwe<T>(string jwe);
+        T DecryptFromKeyVaultJwe<T>(string jwe) where T : notnull;
         string SignWithKey(string data);
         bool VerifyData(string hash, string signature);
     }
@@ -41,6 +41,7 @@ namespace AzureKeyVaultEmulator.Emulator.Services
         }
 
         public T DecryptFromKeyVaultJwe<T>(string jweToken)
+            where T : notnull
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(jweToken);
 
@@ -69,7 +70,8 @@ namespace AzureKeyVaultEmulator.Emulator.Services
             if (string.IsNullOrEmpty(json))
                 throw new InvalidOperationException($"Failed to decrypt JSON string for {nameof(T)}");
 
-            return JsonSerializer.Deserialize<T>(json) ?? throw new InvalidOperationException($"Failed to deserialize JSON to {nameof(T)}");
+            return JsonSerializer.Deserialize<T>(json)
+                ?? throw new SecretException($"Failed to deserialize JSON to {nameof(T)}");
         }
 
         public string CreateKeyVaultJwe(object value)


### PR DESCRIPTION
## Describe your changes

SecretService was broken after the PR in #124 due to the incorrect stores being updated for operations.

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have ran the test suite locally to ensure no breaking changes have been added.
- [x] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [x] I have added new tests, if applicable.