### PR TITLE
Sign and Verify data now behave as expected

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -178,6 +178,9 @@ dotnet_diagnostic.CA2201.severity = suggestion
 # Prefer concrete type instead of var
 dotnet_diagnostic.IDE0008.severity = silent
 
+# Prefer not using GeneratedAttribute format
+dotnet_diagnostic.SYSLIB1045 = silent
+
 # C++ Files
 [*.{cpp,h,in}]
 curly_bracket_next_line = true

--- a/AzureKeyVaultEmulator.IntegrationTests/Keys/KeysControllerTests.cs
+++ b/AzureKeyVaultEmulator.IntegrationTests/Keys/KeysControllerTests.cs
@@ -255,7 +255,6 @@ public sealed class KeysControllerTests(KeysTestingFixture fixture) : IClassFixt
         //var imported = (await client.ImportKeyAsync(null)).Value;
     }
 
-    //[Fact(Skip = "Failing due to VerifyAsync rejecting the signature. Requires fix")]
     [Fact]
     public async Task SignAndVerifyWithKeySucceeds()
     {

--- a/AzureKeyVaultEmulator.IntegrationTests/Keys/KeysControllerTests.cs
+++ b/AzureKeyVaultEmulator.IntegrationTests/Keys/KeysControllerTests.cs
@@ -255,7 +255,8 @@ public sealed class KeysControllerTests(KeysTestingFixture fixture) : IClassFixt
         //var imported = (await client.ImportKeyAsync(null)).Value;
     }
 
-    [Fact(Skip = "Failing due to VerifyAsync rejecting the signature. Requires fix")]
+    //[Fact(Skip = "Failing due to VerifyAsync rejecting the signature. Requires fix")]
+    [Fact]
     public async Task SignAndVerifyWithKeySucceeds()
     {
         // https://github.com/Azure/azure-sdk-for-net/blob/Azure.Security.KeyVault.Keys_4.7.0/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample5_SignVerify.md
@@ -267,8 +268,7 @@ public sealed class KeysControllerTests(KeysTestingFixture fixture) : IClassFixt
 
         var cryptoProvider = await fixture.GetCryptographyClientAsync(key);
 
-        var data = RequestSetup.CreateRandomBytes(64);
-        var digest = SHA256.HashData(data);
+        var digest = RequestSetup.CreateRandomBytes(64);
 
         var signAlgorithm = SignatureAlgorithm.RS256;
 
@@ -277,6 +277,32 @@ public sealed class KeysControllerTests(KeysTestingFixture fixture) : IClassFixt
         var verifyResult = await cryptoProvider.VerifyAsync(signAlgorithm, digest, signResult.Signature);
 
         Assert.True(verifyResult.IsValid);
+    }
+
+    [Fact]
+    public async Task SigningAndVerifyingWithDifferentKeysWillFail()
+    {
+        var client = await fixture.GetClientAsync();
+
+        var signKeyName = fixture.FreshlyGeneratedGuid;
+        var verifyKeyName = fixture.FreshlyGeneratedGuid;
+
+        var signKey = await fixture.CreateKeyAsync(signKeyName);
+        var verifyKey = await fixture.CreateKeyAsync(verifyKeyName);
+
+        var signProvider = await fixture.GetCryptographyClientAsync(signKey);
+        var verifyProvider = await fixture.GetCryptographyClientAsync(verifyKey);
+
+        var data = RequestSetup.CreateRandomBytes(64);
+        var digest = SHA256.HashData(data);
+
+        var signAlgorithm = SignatureAlgorithm.RS256;
+
+        var signResult = await signProvider.SignAsync(signAlgorithm, digest);
+
+        var verifyResult = await verifyProvider.VerifyAsync(signAlgorithm, digest, signResult.Signature);
+
+        Assert.False(verifyResult?.IsValid);
     }
 
     [Fact]

--- a/AzureKeyVaultEmulator.IntegrationTests/SetupHelper/RequestSetup.cs
+++ b/AzureKeyVaultEmulator.IntegrationTests/SetupHelper/RequestSetup.cs
@@ -56,7 +56,7 @@ namespace AzureKeyVaultEmulator.IntegrationTests.SetupHelper
 
             Random.Shared.NextBytes(bytes);
 
-            return bytes.NormaliseForBase64();
+            return bytes;
         }
     }
 }

--- a/AzureKeyVaultEmulator.IntegrationTests/SetupHelper/RequestSetup.cs
+++ b/AzureKeyVaultEmulator.IntegrationTests/SetupHelper/RequestSetup.cs
@@ -45,9 +45,7 @@ namespace AzureKeyVaultEmulator.IntegrationTests.SetupHelper
 
         public static string CreateRandomData(int size = 512)
         {
-            byte[] bytes = new byte[size];
-
-            Random.Shared.NextBytes(bytes);
+            var bytes = CreateRandomBytes(size);
 
             return EncodingUtils.Base64UrlEncode(bytes);
         }
@@ -58,7 +56,7 @@ namespace AzureKeyVaultEmulator.IntegrationTests.SetupHelper
 
             Random.Shared.NextBytes(bytes);
 
-            return bytes;
+            return bytes.NormaliseForBase64();
         }
     }
 }

--- a/AzureKeyVaultEmulator.Shared/Models/Keys/JsonWebKeyModel.cs
+++ b/AzureKeyVaultEmulator.Shared/Models/Keys/JsonWebKeyModel.cs
@@ -65,8 +65,11 @@ namespace AzureKeyVaultEmulator.Shared.Models.Keys
         [JsonPropertyName("y")]
         public string Y { get; set; } = string.Empty;
 
-        private readonly RSA _rsaKey;
-        private readonly RSAParameters _rsaParameters;
+        [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
+        public readonly RSA _rsaKey;
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
+        public readonly RSAParameters _rsaParameters;
 
         public JsonWebKeyModel() : this(RSA.Create())
         {

--- a/AzureKeyVaultEmulator.Shared/Utilities/DataExtensions.cs
+++ b/AzureKeyVaultEmulator.Shared/Utilities/DataExtensions.cs
@@ -1,11 +1,7 @@
-﻿using System.Text.RegularExpressions;
-
-namespace AzureKeyVaultEmulator.Shared.Utilities;
+﻿namespace AzureKeyVaultEmulator.Shared.Utilities;
 
 public static class DataExtensions
 {
-    private static readonly Regex _base64Normalise = new(@"^[\w/\:.-]+;base64,", RegexOptions.Compiled);
-
     /// <summary>
     /// Converts a <see cref="DateTime"/> to a <see cref="DateTimeOffset"/> and returns the epoch time.
     /// </summary>
@@ -30,19 +26,5 @@ public static class DataExtensions
     public static string Neat(this Guid guid)
     {
         return guid.ToString("n");
-    }
-
-    /// <summary>
-    /// Normalises Base64, replacing - with + and _ with /.
-    /// </summary>
-    /// <param name="bytes">The bytes to normalise</param>
-    /// <returns>Normalised <paramref name="bytes"/> which will convert to Base64</returns>
-    public static byte[] NormaliseForBase64(this byte[] bytes)
-    {
-        var str = Convert.ToBase64String(bytes);
-
-        var normalised = _base64Normalise.Replace(str, string.Empty);
-
-        return Convert.FromBase64String(normalised);
     }
 }

--- a/AzureKeyVaultEmulator.Shared/Utilities/DataExtensions.cs
+++ b/AzureKeyVaultEmulator.Shared/Utilities/DataExtensions.cs
@@ -1,7 +1,11 @@
-﻿namespace AzureKeyVaultEmulator.Shared.Utilities;
+﻿using System.Text.RegularExpressions;
+
+namespace AzureKeyVaultEmulator.Shared.Utilities;
 
 public static class DataExtensions
 {
+    private static readonly Regex _base64Normalise = new(@"^[\w/\:.-]+;base64,", RegexOptions.Compiled);
+
     /// <summary>
     /// Converts a <see cref="DateTime"/> to a <see cref="DateTimeOffset"/> and returns the epoch time.
     /// </summary>
@@ -26,5 +30,19 @@ public static class DataExtensions
     public static string Neat(this Guid guid)
     {
         return guid.ToString("n");
+    }
+
+    /// <summary>
+    /// Normalises Base64, replacing - with + and _ with /.
+    /// </summary>
+    /// <param name="bytes">The bytes to normalise</param>
+    /// <returns>Normalised <paramref name="bytes"/> which will convert to Base64</returns>
+    public static byte[] NormaliseForBase64(this byte[] bytes)
+    {
+        var str = Convert.ToBase64String(bytes);
+
+        var normalised = _base64Normalise.Replace(str, string.Empty);
+
+        return Convert.FromBase64String(normalised);
     }
 }

--- a/AzureKeyVaultEmulator.Shared/Utilities/EncodingUtils.cs
+++ b/AzureKeyVaultEmulator.Shared/Utilities/EncodingUtils.cs
@@ -11,15 +11,6 @@ namespace AzureKeyVaultEmulator.Shared.Utilities
             return new StringBuilder(Convert.ToBase64String(bytes)).Replace('+', '-').Replace('/', '_').Replace("=", "").ToString();
         }
 
-        public static string Base64UrlEncode(this string str)
-        {
-            ArgumentException.ThrowIfNullOrWhiteSpace(str);
-
-            var bytes = Encoding.UTF8.GetBytes(str);
-
-            return Base64UrlEncode(bytes);
-        }
-
         public static byte[] Base64UrlDecode(this string encoded)
         {
             encoded = new StringBuilder(encoded).Replace('-', '+').Replace('_', '/').Append('=', (encoded.Length % 4 == 0) ? 0 : 4 - (encoded.Length % 4)).ToString();

--- a/AzureKeyVaultEmulator/Keys/Services/KeyService.cs
+++ b/AzureKeyVaultEmulator/Keys/Services/KeyService.cs
@@ -297,7 +297,7 @@ namespace AzureKeyVaultEmulator.Keys.Services
 
             var key = _keys.SafeGet(cacheId);
 
-            var signature = encryptionService.SignWithKey(digest);
+            var signature = encryptionService.SignWithKey(key.Key._rsaKey, digest);
 
             return new KeyOperationResult
             {
@@ -319,7 +319,7 @@ namespace AzureKeyVaultEmulator.Keys.Services
 
             return new ValueModel<bool>
             {
-                Value = encryptionService.VerifyData(digest, signature)
+                Value = encryptionService.VerifyData(key.Key._rsaKey, digest, signature)
             };
         }
 


### PR DESCRIPTION
Recreating to ensure Integration Test workflow bug fix works too!

## Describe your changes

Corrected the behaviour found in `EncryptionService.SignData` and `EncryptionService.VerifyData` to validate the signature, while also respecting crypto provider key instead of the static RSA instance.

A new test, signing with one key and verifying with another and Asserting a failure has also been added to catch potential regressions.

## Issue ticket number and link

* Fixes: #90 

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have ran the test suite locally to ensure no breaking changes have been added.
- [x] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [x] I have added new tests, if applicable.