### PR TITLE
Modified Aspire.Hosting library to allow .NET 8 targetting

### DIFF
--- a/AzureKeyVaultEmulator.Aspire.Hosting/AzureKeyVaultEmulator.Aspire.Hosting.csproj
+++ b/AzureKeyVaultEmulator.Aspire.Hosting/AzureKeyVaultEmulator.Aspire.Hosting.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -13,7 +13,7 @@
     <Company>James Gould</Company>
     <Description>.NET Aspire AppHost support for the Azure KeyVault Emulator</Description>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
-	  <PackageTags>.net aspire, aspire, aspire.host, aspire.hosting</PackageTags>
+    <PackageTags>.net aspire, aspire, aspire.host, aspire.hosting</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## Describe your changes

Simple fix to allow .NET 8 projects to use the Hosting library.

## Issue ticket number and link

* Fixes: #142 

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have ran the test suite locally to ensure no breaking changes have been added.
- [x] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [x] I have added new tests, if applicable.