### PR TITLE
_token is now assigned token, preventing unnecessary heap allocs

### DIFF
--- a/AzureKeyVaultEmulator.Client/EmulatedTokenCredential.cs
+++ b/AzureKeyVaultEmulator.Client/EmulatedTokenCredential.cs
@@ -54,7 +54,7 @@ namespace AzureKeyVaultEmulator.Aspire.Client
 
                 response.EnsureSuccessStatusCode();
 
-                return await response.Content.ReadAsStringAsync();
+                return _token = await response.Content.ReadAsStringAsync();
             }
             catch
             {


### PR DESCRIPTION
## Describe your changes

The `BearerToken` used for authenticating requests has a lifetime of 5 years, thus requesting for or refreshing the token is unnecessary beyond the first `GetTokenAsync()`. The hot path variable `_token` was never assigned to, thus a `Task<string>` would always hit the heap regardless.

## Issue ticket number and link

* Fixes: #159 

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have ran the test suite locally to ensure no breaking changes have been added.
- [x] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [x] I have added new tests, if applicable.