### PR TITLE
Incorrect status code in requestfailedexception when secret is not found

### DIFF
--- a/AzureKeyVaultEmulator.IntegrationTests/Extensions/Assert/SharedAsserts.cs
+++ b/AzureKeyVaultEmulator.IntegrationTests/Extensions/Assert/SharedAsserts.cs
@@ -9,11 +9,14 @@ public partial class Assert
     /// </summary>
     /// <typeparam name="TResult">The response object for <paramref name="clientAction"/></typeparam>
     /// <param name="clientAction">The client func to execute expecting a failure.</param>
-    public static async Task RequestFailsAsync<TResult>(Func<Task<TResult>> clientAction)
+    /// <param name="expectedStatusCode">Denotes the expected status code for the request, typically NotFound.</param>
+    public static async Task RequestFailsAsync<TResult>(
+        Func<Task<TResult>> clientAction,
+        HttpStatusCode expectedStatusCode = HttpStatusCode.NotFound)
         where TResult : class
     {
         var exception = await ThrowsAsync<RequestFailedException>(clientAction);
 
-        Equal((int)HttpStatusCode.BadRequest, exception?.Status);
+        Equal((int)expectedStatusCode, exception?.Status);
     }
 }

--- a/AzureKeyVaultEmulator.Shared/Exceptions/MissingItemException.cs
+++ b/AzureKeyVaultEmulator.Shared/Exceptions/MissingItemException.cs
@@ -1,0 +1,3 @@
+﻿namespace AzureKeyVaultEmulator.Shared.Exceptions;
+
+public sealed class MissingItemException(string msg) : Exception(msg);

--- a/AzureKeyVaultEmulator.Shared/Utilities/DictionaryUtils.cs
+++ b/AzureKeyVaultEmulator.Shared/Utilities/DictionaryUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using AzureKeyVaultEmulator.Shared.Exceptions;
 
 namespace AzureKeyVaultEmulator.Shared.Utilities;
 
@@ -18,7 +19,7 @@ public static class DictionaryUtils
         var exists = dict.TryGetValue(name, out T? value);
 
         if (!exists || value is null)
-            throw new ArgumentException($"Could not find {name} in vault.");
+            throw new MissingItemException($"Could not find {name} in vault.");
 
         return value;
     }

--- a/AzureKeyVaultEmulator.Shared/Utilities/DictionaryUtils.cs
+++ b/AzureKeyVaultEmulator.Shared/Utilities/DictionaryUtils.cs
@@ -6,13 +6,13 @@ namespace AzureKeyVaultEmulator.Shared.Utilities;
 public static class DictionaryUtils
 {
     /// <summary>
-    /// 
+    /// Retrieves an item from <paramref name="dict"/>, handling null or missing items.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="dict"></param>
-    /// <param name="name"></param>
-    /// <returns></returns>
-    /// <exception cref="ArgumentException"></exception>
+    /// <typeparam name="T">The type for the <paramref name="dict"/> value.</typeparam>
+    /// <param name="dict">The dictionary to query.</param>
+    /// <param name="name">The lookup key.</param>
+    /// <returns>The value associated with <paramref name="name"/> of type <typeparamref name="T"/>.</returns>
+    /// <exception cref="MissingItemException">Thrown when the value for <paramref name="name"/> is null.</exception>
     public static T SafeGet<T>(this ConcurrentDictionary<string, T> dict, string name)
         where T : notnull
     {
@@ -24,9 +24,22 @@ public static class DictionaryUtils
         return value;
     }
 
+    /// <summary>
+    /// Syntactic sugar for an annoying extension method on a Dictionary.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="dict"></param>
+    /// <param name="name"></param>
+    /// <param name="value"></param>
     public static void SafeAddOrUpdate<T>(this ConcurrentDictionary<string, T> dict, string name, T value)
         => dict.AddOrUpdate(name, value, (_, _) => value);
 
+    /// <summary>
+    /// Removes the item for key <paramref name="key"/> from <paramref name="dict"/> without throwing exceptions.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="dict"></param>
+    /// <param name="key"></param>
     public static void SafeRemove<T>(this ConcurrentDictionary<string, T> dict, string key)
         => dict.TryRemove(key, out _);
 }

--- a/AzureKeyVaultEmulator/Middleware/KeyVaultErrorMiddleware.cs
+++ b/AzureKeyVaultEmulator/Middleware/KeyVaultErrorMiddleware.cs
@@ -28,7 +28,9 @@ namespace AzureKeyVaultEmulator.Middleware
                     Message = e.Message
                 };
 
-                context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+                var status = e is MissingItemException ? HttpStatusCode.NotFound : HttpStatusCode.BadRequest;
+
+                context.Response.StatusCode = (int)status;
                 await context.Response.WriteAsJsonAsync(errorResponse);
 
                 return;


### PR DESCRIPTION
## Describe your changes

Previously requests would return back `HttpStatusCode.BadRequest` for *everything*. Items missing from any `store` will now return a `HttpStatusCode.NotFound` status code, from any operation.

## Issue ticket number and link

* Fixes: #162 

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have ran the test suite locally to ensure no breaking changes have been added.
- [x] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [x] I have added new tests, if applicable.