### PR TITLE
Workflow updated to prevent master branch releasing new image when la…

### DIFF
--- a/.github/workflows/docker-build-push-latest-workaround.yml
+++ b/.github/workflows/docker-build-push-latest-workaround.yml
@@ -8,7 +8,24 @@ on:
       - closed
 
 jobs:
+  check-skip-label:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+
+    steps:
+      - name: Check for 'no-release' label
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(label => label.name);
+            const shouldSkip = labels.includes('no-release');
+            core.setOutput('skip', shouldSkip.toString());
+
   build-and-push:
+    needs: check-skip-label
+    if: needs.check-skip-label.outputs.skip != 'true'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
…bel is present on PR

## Describe your changes

Adds support for `no-release` label which prevents master branch PR workflow running a docker image release. Aims to help keep branches in line and prevent merge conflicts etc.

## Issue ticket number and link

* Fixes: #181 