### PR TITLE
Improve key compatibility dev

### DIFF
--- a/src/AzureKeyVaultEmulator.Shared/Constants/EncryptionAlgorithms.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Constants/EncryptionAlgorithms.cs
@@ -4,5 +4,6 @@ namespace AzureKeyVaultEmulator.Shared.Constants
     {
         public const string RSA1_5 = "RSA1_5";
         public const string RSA_OAEP = "RSA-OAEP";
+        public const string RSA_OAEP_256 = "RSA-OAEP-256";
     }
 }

--- a/src/AzureKeyVaultEmulator.Shared/Models/Keys/JsonWebKeyModel.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Keys/JsonWebKeyModel.cs
@@ -7,7 +7,6 @@ using AzureKeyVaultEmulator.Shared.Persistence.Interfaces;
 using AzureKeyVaultEmulator.Shared.Persistence.Utils;
 using AzureKeyVaultEmulator.Shared.Utilities;
 using Microsoft.AspNetCore.Http;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.IdentityModel.Tokens;
 
 namespace AzureKeyVaultEmulator.Shared.Models.Keys

--- a/src/AzureKeyVaultEmulator.Shared/Models/Keys/JsonWebKeyModel.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Keys/JsonWebKeyModel.cs
@@ -122,14 +122,14 @@ namespace AzureKeyVaultEmulator.Shared.Models.Keys
         {
             var parameters = new RSAParameters
             {
-                Modulus = Base64UrlEncoder.DecodeBytes(key.N),
-                Exponent = Base64UrlEncoder.DecodeBytes(key.E),
-                D = string.IsNullOrEmpty(key.D) ? null : Base64UrlEncoder.DecodeBytes(key.D),
-                P = string.IsNullOrEmpty(key.P) ? null : Base64UrlEncoder.DecodeBytes(key.P),
-                Q = string.IsNullOrEmpty(key.Q) ? null : Base64UrlEncoder.DecodeBytes(key.Q),
-                DP = string.IsNullOrEmpty(key.DP) ? null : Base64UrlEncoder.DecodeBytes(key.DP),
-                DQ = string.IsNullOrEmpty(key.DQ) ? null : Base64UrlEncoder.DecodeBytes(key.DQ),
-                InverseQ = string.IsNullOrEmpty(key.QI) ? null : Base64UrlEncoder.DecodeBytes(key.QI)
+                Modulus = EncodingUtils.Base64UrlDecode(key.N),
+                Exponent = EncodingUtils.Base64UrlDecode(key.E),
+                D = string.IsNullOrEmpty(key.D) ? null : EncodingUtils.Base64UrlDecode(key.D),
+                P = string.IsNullOrEmpty(key.P) ? null : EncodingUtils.Base64UrlDecode(key.P),
+                Q = string.IsNullOrEmpty(key.Q) ? null : EncodingUtils.Base64UrlDecode(key.Q),
+                DP = string.IsNullOrEmpty(key.DP) ? null : EncodingUtils.Base64UrlDecode(key.DP),
+                DQ = string.IsNullOrEmpty(key.DQ) ? null : EncodingUtils.Base64UrlDecode(key.DQ),
+                InverseQ = string.IsNullOrEmpty(key.QI) ? null : EncodingUtils.Base64UrlDecode(key.QI)
             };
 
             RSAKey = RSA.Create(parameters);

--- a/src/AzureKeyVaultEmulator/Keys/Controllers/KeysController.cs
+++ b/src/AzureKeyVaultEmulator/Keys/Controllers/KeysController.cs
@@ -65,7 +65,6 @@ namespace AzureKeyVaultEmulator.Keys.Controllers
             return Ok(result);
         }
 
-        
         [HttpPatch("{name}")]
         public async Task<IActionResult> UpdateKeyWithoutVersion(
             [FromRoute] string name,
@@ -134,6 +133,17 @@ namespace AzureKeyVaultEmulator.Keys.Controllers
             return Ok(result);
         }
 
+        [HttpPost("{name}/encrypt")]
+        public async Task<IActionResult> Encrypt(
+           [FromRoute] string name,
+           [ApiVersion] string apiVersion,
+           [FromBody] KeyOperationParameters keyOperationParameters)
+        {
+            var result = await keyService.EncryptAsync(name, string.Empty, keyOperationParameters);
+
+            return Ok(result);
+        }
+
         [HttpPost("{name}/{version}/decrypt")]
         public async Task<IActionResult> Decrypt(
             [FromRoute] string name,
@@ -142,6 +152,17 @@ namespace AzureKeyVaultEmulator.Keys.Controllers
             [FromBody] KeyOperationParameters keyOperationParameters)
         {
             var result = await keyService.DecryptAsync(name, version, keyOperationParameters);
+
+            return Ok(result);
+        }
+
+        [HttpPost("{name}/decrypt")]
+        public async Task<IActionResult> Decrypt(
+           [FromRoute] string name,
+           [ApiVersion] string apiVersion,
+           [FromBody] KeyOperationParameters keyOperationParameters)
+        {
+            var result = await keyService.DecryptAsync(name, string.Empty, keyOperationParameters);
 
             return Ok(result);
         }

--- a/src/AzureKeyVaultEmulator/Keys/Services/KeyService.cs
+++ b/src/AzureKeyVaultEmulator/Keys/Services/KeyService.cs
@@ -103,7 +103,6 @@ namespace AzureKeyVaultEmulator.Keys.Services
         public async Task<KeyOperationResult?> EncryptAsync(string name, string version, KeyOperationParameters keyOperationParameters)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(name);
-            ArgumentException.ThrowIfNullOrWhiteSpace(version);
 
             var foundKey = await context.Keys.SafeGetAsync(name, version);
 
@@ -119,7 +118,6 @@ namespace AzureKeyVaultEmulator.Keys.Services
         public async Task<KeyOperationResult?> DecryptAsync(string name, string version, KeyOperationParameters keyOperationParameters)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(name);
-            ArgumentException.ThrowIfNullOrWhiteSpace(version);
 
             var foundKey = await context.Keys.SafeGetAsync(name, version);
 

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Keys/KeysControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Keys/KeysControllerTests.cs
@@ -320,11 +320,9 @@ public sealed class KeysControllerTests(KeysTestingFixture fixture) : IClassFixt
         Assert.NotEqual(data, encrypted.Ciphertext);
 
          var decrypted = keyPair.Decrypt(encrypted.Ciphertext, encryptionPadding);
-        //var decrypted = (await cryptoClient.DecryptAsync(algo, encrypted.Ciphertext)).Plaintext;
 
         Assert.NotEqual(decrypted, encrypted.Ciphertext);
         Assert.Equal(decrypted, data);
-        //Assert.NotNull(encryptionPadding);
     }
 
     [Fact]

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Keys/KeysControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Keys/KeysControllerTests.cs
@@ -8,6 +8,20 @@ namespace AzureKeyVaultEmulator.IntegrationTests.Keys;
 
 public sealed class KeysControllerTests(KeysTestingFixture fixture) : IClassFixture<KeysTestingFixture>
 {
+    public static TheoryData<EncryptionAlgorithm> SupportedEncryptionAlgorithms => new TheoryData<EncryptionAlgorithm>
+    {
+        EncryptionAlgorithm.Rsa15,
+        EncryptionAlgorithm.RsaOaep,
+        EncryptionAlgorithm.RsaOaep256,
+    };
+
+    public static TheoryData<EncryptionAlgorithm, RSAEncryptionPadding> SupportedEncryptionAlgorithmsAndPadding => new TheoryData<EncryptionAlgorithm, RSAEncryptionPadding>
+    {
+        { EncryptionAlgorithm.Rsa15, RSAEncryptionPadding.Pkcs1 },
+        { EncryptionAlgorithm.RsaOaep, RSAEncryptionPadding.OaepSHA1 },
+        { EncryptionAlgorithm.RsaOaep256, RSAEncryptionPadding.OaepSHA256 },
+    };
+
     [Fact]
     public async Task CreateAndGetKeySucceeds()
     {
@@ -80,7 +94,7 @@ public sealed class KeysControllerTests(KeysTestingFixture fixture) : IClassFixt
         };
 
         newProps.Tags.Add(tagKey, tagValue);
-        
+
         var disabledKeyWithTags = (await client.UpdateKeyPropertiesAsync(newProps)).Value;
 
         var shouldBeUpdated = (await client.GetKeyAsync(keyName, disabledKeyWithTags.Properties.Version)).Value;
@@ -126,7 +140,7 @@ public sealed class KeysControllerTests(KeysTestingFixture fixture) : IClassFixt
         List<string> matchingKeys = [];
 
         await foreach (var key in client.GetPropertiesOfKeysAsync())
-            if(!string.IsNullOrEmpty(key.Name) && key.Name.Contains(keyName))
+            if (!string.IsNullOrEmpty(key.Name) && key.Name.Contains(keyName))
                 matchingKeys.Add(key.Name);
 
         Assert.Equal(executionCount, matchingKeys.Count);
@@ -151,8 +165,9 @@ public sealed class KeysControllerTests(KeysTestingFixture fixture) : IClassFixt
         Assert.Equal(executionCount, matchingKeys.Count);
     }
 
-    [Fact]
-    public async Task EncryptAndDecryptWithKeySucceeds()
+    [Theory]
+    [MemberData(nameof(SupportedEncryptionAlgorithms))]
+    public async Task EncryptAndDecryptWithKeySucceeds(EncryptionAlgorithm algo)
     {
         var client = await fixture.GetClientAsync();
 
@@ -164,7 +179,35 @@ public sealed class KeysControllerTests(KeysTestingFixture fixture) : IClassFixt
 
         var data = RequestSetup.CreateRandomBytes(128);
 
-        var algo = EncryptionAlgorithm.RsaOaep;
+        var cryptoClient = client.GetCryptographyClient(keyName, key.Properties.Version);
+
+        var encrypted = await cryptoClient.EncryptAsync(algo, data);
+
+        Assert.NotEqual(data, encrypted.Ciphertext);
+
+        var decrypted = await cryptoClient.DecryptAsync(algo, encrypted.Ciphertext);
+
+        Assert.NotEqual(decrypted.Plaintext, encrypted.Ciphertext);
+        Assert.Equal(decrypted.Plaintext, data);
+    }
+
+    [Theory]
+    [MemberData(nameof(SupportedEncryptionAlgorithms))]
+    public async Task EncryptAndDecryptWithImportedKeySucceeds(EncryptionAlgorithm algo)
+    {
+        var client = await fixture.GetClientAsync();
+
+        var keyName = fixture.FreshlyGeneratedGuid;
+
+        using var keyPair = RSA.Create();
+
+        var jwk = new JsonWebKey(keyPair, true);
+
+        var key = (await client.ImportKeyAsync(keyName, jwk)).Value;
+
+        Assert.Equal(keyName, key.Name);
+
+        var data = RequestSetup.CreateRandomBytes(128);
 
         var cryptoClient = client.GetCryptographyClient(keyName, key.Properties.Version);
 
@@ -176,6 +219,112 @@ public sealed class KeysControllerTests(KeysTestingFixture fixture) : IClassFixt
 
         Assert.NotEqual(decrypted.Plaintext, encrypted.Ciphertext);
         Assert.Equal(decrypted.Plaintext, data);
+    }
+
+    [Theory]
+    [MemberData(nameof(SupportedEncryptionAlgorithmsAndPadding))]
+    public async Task EncryptWithPublicKeyAndDecryptWithVaultKeySucceeds(EncryptionAlgorithm algo, RSAEncryptionPadding encryptionPadding)
+    {
+        var client = await fixture.GetClientAsync();
+
+        var keyName = fixture.FreshlyGeneratedGuid;
+
+        var key = (await client.CreateKeyAsync(keyName, KeyType.Rsa)).Value;
+
+        Assert.Equal(keyName, key.Name);
+
+        var data = RequestSetup.CreateRandomBytes(128);
+
+        var cryptoClient = client.GetCryptographyClient(keyName, key.Properties.Version);
+
+        var publicKeyParameters = new RSAParameters()
+        {
+            Exponent = key.Key.E,
+            Modulus = key.Key.N,
+        };
+
+        using var publicKey = RSA.Create(publicKeyParameters);
+
+        var encrypted = publicKey.Encrypt(data, encryptionPadding);
+
+        Assert.NotEqual(data, encrypted);
+
+        var decrypted = await cryptoClient.DecryptAsync(algo, encrypted);
+
+        Assert.NotEqual(decrypted.Plaintext, encrypted);
+        Assert.Equal(decrypted.Plaintext, data);
+    }
+
+    [Theory]
+    [MemberData(nameof(SupportedEncryptionAlgorithmsAndPadding))]
+    public async Task EncryptWithPublicKeyAndDecryptWithImportedVaultKeySucceeds(EncryptionAlgorithm algo, RSAEncryptionPadding encryptionPadding)
+    {
+        var client = await fixture.GetClientAsync();
+
+        var keyName = fixture.FreshlyGeneratedGuid;
+
+        using var keyPair = RSA.Create();
+
+        var jwk = new JsonWebKey(keyPair, true);
+
+        var key = (await client.ImportKeyAsync(keyName, jwk)).Value;
+
+        Assert.Equal(keyName, key.Name);
+
+        var data = RequestSetup.CreateRandomBytes(128);
+
+        var cryptoClient = client.GetCryptographyClient(keyName, key.Properties.Version);
+
+        var publicKeyParameters = new RSAParameters()
+        {
+            Exponent = key.Key.E,
+            Modulus = key.Key.N,
+        };
+
+        using var publicKey = RSA.Create(publicKeyParameters);
+
+        var encrypted = publicKey.Encrypt(data, encryptionPadding);
+
+        Assert.NotEqual(data, encrypted);
+
+        var decrypted = await cryptoClient.DecryptAsync(algo, encrypted);
+
+        Assert.NotEqual(decrypted.Plaintext, encrypted);
+        Assert.Equal(decrypted.Plaintext, data);
+    }
+
+    [Theory]
+    [MemberData(nameof(SupportedEncryptionAlgorithmsAndPadding))]
+    public async Task EncryptWithVaultKeyAndDecryptWithPrivateKeySucceeds(EncryptionAlgorithm algo, RSAEncryptionPadding encryptionPadding)
+    {
+        var client = await fixture.GetClientAsync();
+
+        var keyName = fixture.FreshlyGeneratedGuid;
+
+        using var keyPair = RSA.Create();
+
+        var jwk = new JsonWebKey(keyPair, true);
+
+        var key = (await client.ImportKeyAsync(keyName, jwk)).Value;
+
+        Assert.Equal(keyName, key.Name);
+        Assert.Equal(jwk.E, key.Key.E);
+        Assert.Equal(jwk.N, key.Key.N);
+
+        var data = RequestSetup.CreateRandomBytes(128);
+
+        var cryptoClient = client.GetCryptographyClient(keyName, key.Properties.Version);
+
+        var encrypted = await cryptoClient.EncryptAsync(algo, data);
+
+        Assert.NotEqual(data, encrypted.Ciphertext);
+
+         var decrypted = keyPair.Decrypt(encrypted.Ciphertext, encryptionPadding);
+        //var decrypted = (await cryptoClient.DecryptAsync(algo, encrypted.Ciphertext)).Plaintext;
+
+        Assert.NotEqual(decrypted, encrypted.Ciphertext);
+        Assert.Equal(decrypted, data);
+        //Assert.NotNull(encryptionPadding);
     }
 
     [Fact]


### PR DESCRIPTION
## Describe your changes

This improves compatibility of key encryption/decryption by
- Adding support the RSA OAEP 256 Algorithm
- Base64Url encoding and decoding payloads
- Not overriding key material when importing a key
- Adding endpoints for encrypting/decrypting without providing the key version

This allows the emulator to support use cases where encryption or decryption is not performed by the emulator and allows to use the [Microsoft recommended algorithm](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys-details).


## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have ran the test suite locally to ensure no breaking changes have been added.
- [x] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [x] I have added new tests, if applicable.