### PR TITLE
Development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,24 @@
-# Use official .NET 9 SDK image for building
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /app
 
-# Copy solution and restore dependencies
 COPY AzureKeyVaultEmulator.sln ./ 
 COPY src/AzureKeyVaultEmulator/*.csproj src/AzureKeyVaultEmulator/
 COPY src/AzureKeyVaultEmulator.Shared/*.csproj src/AzureKeyVaultEmulator.Shared/
 RUN dotnet restore src/AzureKeyVaultEmulator/AzureKeyVaultEmulator.csproj
 
-# Copy everything and build
 COPY . ./
 WORKDIR /app/src/AzureKeyVaultEmulator
 RUN dotnet publish -c Release -o /out
 
-# Use runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime
 WORKDIR /app
 
-# Install ca-certificates and openssl to handle .crt/.pfx
-RUN apt-get update && \
-    apt-get install -y ca-certificates openssl && \
-    update-ca-certificates
-
-# Sets the ENV VARS for ASP.NET Core to expect these certificates
 ENV ASPNETCORE_URLS=https://+:4997
 ENV ASPNETCORE_Kestrel__Certificates__Default__Path=/certs/emulator.pfx
 ENV ASPNETCORE_Kestrel__Certificates__Default__Password=emulator
 
-# Copy published .NET application
 COPY --from=build /out ./
 
-# Expose 4997 so host can reach it
 EXPOSE 4997
 
-# When the container starts we EXPECT a volume to map to certs/
-# and we then need to install the certificates into the container for trusted SSL.
-# If this fails the container kills, which is expected and good.
-ENTRYPOINT ["bash", "-c", "cp /certs/emulator.crt /usr/local/share/ca-certificates/emulator.crt && update-ca-certificates && exec dotnet AzureKeyVaultEmulator.dll"]
+ENTRYPOINT ["dotnet", "AzureKeyVaultEmulator.dll"]

--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/Constants/KeyVaultEmulatorContainerConstants.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/Constants/KeyVaultEmulatorContainerConstants.cs
@@ -8,11 +8,7 @@
         public const string Image = "jamesgoulddev/azure-keyvault-emulator";
         public const int Port = 4997;
 
-#if DEBUG
-        public const string Tag = "dev-unstable";
-#else
         public const string Tag = "latest";
-#endif
     }
 
     internal partial class KeyVaultEmulatorContainerConstants


### PR DESCRIPTION
## Describe your changes

Drops the hard dep on `emulator.crt` to be present in the `/certs/` directory (and thus volume/mount) as it's not required.

## Issue ticket number and link

* Fixes: #224 

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have ran the test suite locally to ensure no breaking changes have been added.
- [x] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [x] I have added new tests, if applicable.