### PR TITLE
Bug/246 certificate contacts empty

### DIFF
--- a/src/AzureKeyVaultEmulator/Certificates/Services/CertificateBackingService.cs
+++ b/src/AzureKeyVaultEmulator/Certificates/Services/CertificateBackingService.cs
@@ -134,7 +134,10 @@ public sealed class CertificateBackingService(
 
     public async Task<CertificateContacts> DeleteCertificateContactsAsync()
     {
-        var contacts = await context.CertificateContacts.Where(x => x.Deleted == false).SingleAsync();
+        var contacts = await context.CertificateContacts.Where(x => x.Deleted == false).FirstOrDefaultAsync();
+
+        if (contacts is null)
+            return new();
 
         contacts.Deleted = true;
 
@@ -145,7 +148,9 @@ public sealed class CertificateBackingService(
 
     public async Task<CertificateContacts> GetCertificateContactsAsync()
     {
-        return await context.CertificateContacts.Where(x => x.Deleted == false).SingleAsync();
+        var contacts = await context.CertificateContacts.Where(x => x.Deleted == false).FirstOrDefaultAsync();
+
+        return contacts ??= new();
     }
 
     private async Task<KeyBundle> CreateBackingKeyAsync(

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/CertificateContactTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/CertificateContactTests.cs
@@ -30,13 +30,19 @@ public class CertificateContactTests(CertificatesTestingFixture fixture) : IClas
 
         var fromStore = await client.GetContactsAsync();
 
+        Assert.NotNull(fromStore);
+
         Assert.Equivalent(fromStore?.Value, contacts);
 
         var deleteResponse = await client.DeleteContactsAsync();
 
         Assert.NotNull(deleteResponse.Value);
 
-        await Assert.RequestFailsAsync(() => client.GetContactsAsync(), HttpStatusCode.BadRequest);
+        var contactsAfterDelete = await client.GetContactsAsync();
+
+        Assert.NotNull(contactsAfterDelete.Value);
+
+        Assert.Empty(contactsAfterDelete.Value);
     }
 
     private async Task TryDeleteExistingContacts()


### PR DESCRIPTION
## Describe your changes

Corrects the response for `CertificateClient.GetContacts{Async}` to provide an empty array instead of throwing an `Sequence contains no elements` error.

* Fixes: #246 

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have ran the test suite locally to ensure no breaking changes have been added.
- [x] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [x] I have added new tests, if applicable.