### PR TITLE
Update the certificate update controller and service to match the documentation schema 

### DIFF
--- a/dev/WebApiWithEmulator.DebugHelper/WebApiPWithEmulator/WebApiWithEmulator.DebugHelper.csproj
+++ b/dev/WebApiWithEmulator.DebugHelper/WebApiPWithEmulator/WebApiWithEmulator.DebugHelper.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.14.0" />
+    <PackageReference Include="Azure.Identity" Version="1.14.1" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.8.0" />
-    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.7.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.8.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.12.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />

--- a/src/AzureKeyVaultEmulator.Client/AzureKeyVaultEmulator.Client.csproj
+++ b/src/AzureKeyVaultEmulator.Client/AzureKeyVaultEmulator.Client.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.46.2" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.8.0" />
-    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.7.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.8.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.3.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"

--- a/src/AzureKeyVaultEmulator/Certificates/Controllers/CertificatesController.cs
+++ b/src/AzureKeyVaultEmulator/Certificates/Controllers/CertificatesController.cs
@@ -69,7 +69,7 @@ public class CertificatesController(
     }
 
     /// <summary>
-    /// Might not be needed, can't remember the exact flow. 
+    /// Might not be needed, can't remember the exact flow.
     /// </summary>
     [HttpGet("{name}/completed")]
     public async Task<IActionResult> GetCompletedCertificate(
@@ -108,16 +108,17 @@ public class CertificatesController(
         return Ok(result);
     }
 
-    [HttpPatch("{name}")]
+    [HttpPatch("{name}/{version?}")]
     public async Task<IActionResult> UpdateCertificate(
         [FromRoute] string name,
+        [FromRoute] string? version,
         [FromBody] UpdateCertificateRequest request,
         [ApiVersion] string apiVersion)
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
         ArgumentNullException.ThrowIfNull(request);
 
-        var result = await certService.UpdateCertificateAsync(name, request);
+        var result = await certService.UpdateCertificateAsync(name, version, request);
 
         return Ok(result);
     }

--- a/src/AzureKeyVaultEmulator/Certificates/Services/CertificateService.cs
+++ b/src/AzureKeyVaultEmulator/Certificates/Services/CertificateService.cs
@@ -99,12 +99,12 @@ public sealed class CertificateService(
         return policy;
     }
 
-    public async Task<CertificateBundle> UpdateCertificateAsync(string name, UpdateCertificateRequest request)
+    public async Task<CertificateBundle> UpdateCertificateAsync(string name, string? version, UpdateCertificateRequest request)
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
         ArgumentNullException.ThrowIfNull(request);
 
-        var cert = await context.Certificates.SafeGetAsync(name);
+        var cert = await context.Certificates.SafeGetAsync(name, version: version ?? string.Empty);
 
         cert.CertificatePolicy = request.Policy ??= cert.CertificatePolicy;
         cert.Attributes = request.Attributes ?? cert.Attributes;

--- a/src/AzureKeyVaultEmulator/Certificates/Services/ICertificateService.cs
+++ b/src/AzureKeyVaultEmulator/Certificates/Services/ICertificateService.cs
@@ -12,7 +12,7 @@ public interface ICertificateService
     Task<ListResult<CertificateVersionItem>> GetCertificateVersionsAsync(string name, int maxResults = 25, int skipCount = 25);
 
     Task<CertificateOperation> GetPendingCertificateAsync(string name);
-    Task<CertificateBundle> UpdateCertificateAsync(string name, UpdateCertificateRequest request);
+    Task<CertificateBundle> UpdateCertificateAsync(string name, string? version, UpdateCertificateRequest request);
     Task<CertificatePolicy> UpdateCertificatePolicyAsync(string name, CertificatePolicy certificatePolicy);
     Task<CertificatePolicy> GetCertificatePolicyAsync(string name);
     Task<IssuerBundle> GetCertificateIssuerAsync(string name);

--- a/src/TestContainers/dotnet/AzureKeyVaultEmulator.TestContainers.csproj
+++ b/src/TestContainers/dotnet/AzureKeyVaultEmulator.TestContainers.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.8.0" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.8.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
-    <PackageReference Include="Testcontainers" Version="4.0.0" />
+    <PackageReference Include="Testcontainers" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AzureKeyVaultEmulator.IntegrationTests/AzureKeyVaultEmulator.IntegrationTests.csproj
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/AzureKeyVaultEmulator.IntegrationTests.csproj
@@ -11,9 +11,9 @@
     <PackageReference Include="Aspire.Hosting.Testing" Version="9.3.1" />
     <PackageReference Include="Asp.Versioning.Http" Version="8.1.0" />
     <PackageReference Include="Asp.Versioning.Http.Client" Version="8.1.0" />
-    <PackageReference Include="Azure.Identity" Version="1.14.0" />
+    <PackageReference Include="Azure.Identity" Version="1.14.1" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.8.0" />
-    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.7.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.8.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.6" />

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/CertificatesControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/CertificatesControllerTests.cs
@@ -255,6 +255,34 @@ public class CertificatesControllerTests(CertificatesTestingFixture fixture)
     }
 
     [Fact]
+    public async Task UpdatingCertificatePropertiesWithVersionWillPersistChange()
+    {
+        var client = await fixture.GetClientAsync();
+
+        var certName = fixture.FreshlyGeneratedGuid;
+
+        await fixture.CreateCertificateAsync(certName);
+
+        var fromStore = await client.GetCertAsync(certName);
+
+        Assert.NotNull(fromStore);
+        Assert.NotNull(fromStore.Properties);
+
+        var updatedProperties = new CertificateProperties(fromStore.Id)
+        {
+            Enabled = false
+        };
+
+        var response = await client.UpdateCertificatePropertiesAsync(updatedProperties);
+
+        Assert.NotNull(response.Value);
+
+        var updatedFromStore = await client.GetCertAsync(certName);
+
+        Assert.Equal(updatedProperties.Enabled, updatedFromStore.Properties.Enabled);
+    }
+
+    [Fact]
     public async Task GetCertificatePolicyWillSucceed()
     {
         var client = await fixture.GetClientAsync();

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/CertificatesControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/CertificatesControllerTests.cs
@@ -283,6 +283,26 @@ public class CertificatesControllerTests(CertificatesTestingFixture fixture)
     }
 
     [Fact]
+    public async Task UriWIllUpdateCertificatePropertiesVersion()
+    {
+        var client = await fixture.GetClientAsync();
+
+        var certName = fixture.FreshlyGeneratedGuid;
+
+        await fixture.CreateCertificateAsync(certName);
+
+        var fromStore = await client.GetCertAsync(certName);
+
+        Assert.NotNull(fromStore);
+        Assert.NotNull(fromStore.Properties);
+
+        var updatedProperties = new CertificateProperties(fromStore.Id);
+
+        Assert.False(string.IsNullOrEmpty(updatedProperties.Version));
+        Assert.Equal(fromStore.Properties.Version, updatedProperties.Version);
+    }
+
+    [Fact]
     public async Task GetCertificatePolicyWillSucceed()
     {
         var client = await fixture.GetClientAsync();

--- a/test/AzureKeyVaultEmulator.TestContainers.Tests/AzureKeyVaultEmulator.TestContainers.Tests.csproj
+++ b/test/AzureKeyVaultEmulator.TestContainers.Tests/AzureKeyVaultEmulator.TestContainers.Tests.csproj
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Describe your changes

Complementary fix to the certificate update endpoint since I was incorrect on the actual URL used by the .NET SDK.

Documentation used https://learn.microsoft.com/en-us/rest/api/keyvault/certificates/update-certificate/update-certificate?view=rest-keyvault-certificates-7.4&tabs=HTTP

## Issue ticket number and link

* Fixes: #252

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have ran the test suite locally to ensure no breaking changes have been added.
- [x] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [x] I have added new tests, if applicable.