### PR TITLE
UpdateCertificate now matches API Scheme (#262)

### DIFF
--- a/src/AzureKeyVaultEmulator/Certificates/Controllers/CertificatesController.cs
+++ b/src/AzureKeyVaultEmulator/Certificates/Controllers/CertificatesController.cs
@@ -69,7 +69,7 @@ public class CertificatesController(
     }
 
     /// <summary>
-    /// Might not be needed, can't remember the exact flow. 
+    /// Might not be needed, can't remember the exact flow.
     /// </summary>
     [HttpGet("{name}/completed")]
     public async Task<IActionResult> GetCompletedCertificate(
@@ -108,16 +108,17 @@ public class CertificatesController(
         return Ok(result);
     }
 
-    [HttpPatch("{name}")]
+    [HttpPatch("{name}/{version?}")]
     public async Task<IActionResult> UpdateCertificate(
         [FromRoute] string name,
+        [FromRoute] string? version,
         [FromBody] UpdateCertificateRequest request,
         [ApiVersion] string apiVersion)
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
         ArgumentNullException.ThrowIfNull(request);
 
-        var result = await certService.UpdateCertificateAsync(name, request);
+        var result = await certService.UpdateCertificateAsync(name, version, request);
 
         return Ok(result);
     }

--- a/src/AzureKeyVaultEmulator/Certificates/Services/CertificateService.cs
+++ b/src/AzureKeyVaultEmulator/Certificates/Services/CertificateService.cs
@@ -99,12 +99,12 @@ public sealed class CertificateService(
         return policy;
     }
 
-    public async Task<CertificateBundle> UpdateCertificateAsync(string name, UpdateCertificateRequest request)
+    public async Task<CertificateBundle> UpdateCertificateAsync(string name, string? version, UpdateCertificateRequest request)
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
         ArgumentNullException.ThrowIfNull(request);
 
-        var cert = await context.Certificates.SafeGetAsync(name);
+        var cert = await context.Certificates.SafeGetAsync(name, version: version ?? string.Empty);
 
         cert.CertificatePolicy = request.Policy ??= cert.CertificatePolicy;
         cert.Attributes = request.Attributes ?? cert.Attributes;

--- a/src/AzureKeyVaultEmulator/Certificates/Services/ICertificateService.cs
+++ b/src/AzureKeyVaultEmulator/Certificates/Services/ICertificateService.cs
@@ -12,7 +12,7 @@ public interface ICertificateService
     Task<ListResult<CertificateVersionItem>> GetCertificateVersionsAsync(string name, int maxResults = 25, int skipCount = 25);
 
     Task<CertificateOperation> GetPendingCertificateAsync(string name);
-    Task<CertificateBundle> UpdateCertificateAsync(string name, UpdateCertificateRequest request);
+    Task<CertificateBundle> UpdateCertificateAsync(string name, string? version, UpdateCertificateRequest request);
     Task<CertificatePolicy> UpdateCertificatePolicyAsync(string name, CertificatePolicy certificatePolicy);
     Task<CertificatePolicy> GetCertificatePolicyAsync(string name);
     Task<IssuerBundle> GetCertificateIssuerAsync(string name);

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/CertificatesControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/CertificatesControllerTests.cs
@@ -255,6 +255,54 @@ public class CertificatesControllerTests(CertificatesTestingFixture fixture)
     }
 
     [Fact]
+    public async Task UpdatingCertificatePropertiesWithVersionWillPersistChange()
+    {
+        var client = await fixture.GetClientAsync();
+
+        var certName = fixture.FreshlyGeneratedGuid;
+
+        await fixture.CreateCertificateAsync(certName);
+
+        var fromStore = await client.GetCertAsync(certName);
+
+        Assert.NotNull(fromStore);
+        Assert.NotNull(fromStore.Properties);
+
+        var updatedProperties = new CertificateProperties(fromStore.Id)
+        {
+            Enabled = false
+        };
+
+        var response = await client.UpdateCertificatePropertiesAsync(updatedProperties);
+
+        Assert.NotNull(response.Value);
+
+        var updatedFromStore = await client.GetCertAsync(certName);
+
+        Assert.Equal(updatedProperties.Enabled, updatedFromStore.Properties.Enabled);
+    }
+
+    [Fact]
+    public async Task UriWIllUpdateCertificatePropertiesVersion()
+    {
+        var client = await fixture.GetClientAsync();
+
+        var certName = fixture.FreshlyGeneratedGuid;
+
+        await fixture.CreateCertificateAsync(certName);
+
+        var fromStore = await client.GetCertAsync(certName);
+
+        Assert.NotNull(fromStore);
+        Assert.NotNull(fromStore.Properties);
+
+        var updatedProperties = new CertificateProperties(fromStore.Id);
+
+        Assert.False(string.IsNullOrEmpty(updatedProperties.Version));
+        Assert.Equal(fromStore.Properties.Version, updatedProperties.Version);
+    }
+
+    [Fact]
     public async Task GetCertificatePolicyWillSucceed()
     {
         var client = await fixture.GetClientAsync();


### PR DESCRIPTION
Fixes: #262 

* Allow to update specific certificate versions

* Update certificate properties update endpoint to be aligned with the documentation https://learn.microsoft.com/en-us/rest/api/keyvault/certificates/update-certificate/update-certificate?view=rest-keyvault-certificates-7.4&tabs=HTTP

* Added test to validate that the certificate properties correctly populate the "Version" properties used to determine the version of the certificate to update
