### PR TITLE
Backing secret for Certificate now has the value set to the raw contents of the cert (#263)

### DIFF
--- a/src/AzureKeyVaultEmulator/Certificates/Services/CertificateService.cs
+++ b/src/AzureKeyVaultEmulator/Certificates/Services/CertificateService.cs
@@ -26,7 +26,7 @@ public sealed class CertificateService(
 
         var certificate = X509CertificateFactory.BuildX509Certificate(name, policy);
 
-        var (backingKey, backingSecret) = await backingService.GetBackingComponentsAsync(name, policy);
+        var (backingKey, backingSecret) = await backingService.GetBackingComponentsAsync(name, certificate, policy);
 
         var version = Guid.NewGuid().Neat();
 
@@ -212,7 +212,7 @@ public sealed class CertificateService(
 
         var certificate = X509CertificateFactory.ImportFromBase64(request.Value);
 
-        var (backingKey, backingSecret) = await backingService.GetBackingComponentsAsync(name);
+        var (backingKey, backingSecret) = await backingService.GetBackingComponentsAsync(name, certificate);
 
         var attributes = new CertificateAttributesModel
         {

--- a/src/AzureKeyVaultEmulator/Certificates/Services/ICertificateBackingService.cs
+++ b/src/AzureKeyVaultEmulator/Certificates/Services/ICertificateBackingService.cs
@@ -1,4 +1,5 @@
-﻿using AzureKeyVaultEmulator.Shared.Models.Certificates;
+﻿using System.Security.Cryptography.X509Certificates;
+using AzureKeyVaultEmulator.Shared.Models.Certificates;
 using AzureKeyVaultEmulator.Shared.Models.Certificates.Requests;
 using AzureKeyVaultEmulator.Shared.Models.Secrets;
 
@@ -6,7 +7,7 @@ namespace AzureKeyVaultEmulator.Certificates.Services;
 
 public interface ICertificateBackingService
 {
-    Task<(KeyBundle backingKey, SecretBundle backingSecret)> GetBackingComponentsAsync(string certName, CertificatePolicy? policy = null);
+    Task<(KeyBundle backingKey, SecretBundle backingSecret)> GetBackingComponentsAsync(string certName, X509Certificate2? cert, CertificatePolicy? policy = null);
 
     Task<IssuerBundle> GetIssuerAsync(string name);
     Task<IssuerBundle> CreateIssuerAsync(string name, IssuerBundle bundle);

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/CertificatesControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/CertificatesControllerTests.cs
@@ -497,6 +497,27 @@ public class CertificatesControllerTests(CertificatesTestingFixture fixture)
         await Assert.RequestFailsAsync(() => client.GetCertAsync(certName));
     }
 
+    [Fact]
+    public async Task DownloadingCertificateWillProvideIdenticalCopy()
+    {
+        var client = await fixture.GetClientAsync();
+
+        var certName = fixture.FreshlyGeneratedGuid;
+
+        var operation = await client.StartCreateCertificateAsync(certName, fixture.BasicPolicy);
+
+        await operation.WaitForCompletionAsync();
+
+        var certFromStore = await client.GetCertAsync(certName);
+
+        Assert.NotNull(certFromStore);
+        Assert.Equal(certName, certFromStore.Name);
+
+        var downloadedCertificate = await client.DownloadCertificateAsync(certName);
+
+        Assert.NotNull(downloadedCertificate.Value);
+    }
+
     [Fact(Skip = @"
         Certificate Operations are currently hardcoded to work in a specific way,
         this functionality requires a refactor of the CertificateOperation class and


### PR DESCRIPTION
## Describe your changes

The Azure SDK requires the backing secret for a certificate to have the `secret.Value` set to the `Base64` encoded value of the `cert.RawData`:

```csharp
            try
            {
                KeyVaultCertificateWithPolicy certificate = await _pipeline.SendRequestAsync(RequestMethod.Get, () => new KeyVaultCertificateWithPolicy(), cancellationToken, CertificatesPath, options.CertificateName, "/", options.Version).ConfigureAwait(false);
                Response<KeyVaultSecret> secretResponse = await _pipeline.SendRequestAsync(RequestMethod.Get, () => new KeyVaultSecret(), certificate.SecretId, cancellationToken).ConfigureAwait(false);

                KeyVaultSecret secret = secretResponse.Value;
                string value = secret.Value;

                if (string.IsNullOrEmpty(value))
                {
                    throw new InvalidDataException($"Secret {certificate.SecretId} contains no value");
                }

                if (secret.ContentType is null || secret.ContentType == CertificateContentType.Pkcs12)
                {
                    byte[] rawData = Convert.FromBase64String(value);

                    X509Certificate2 x509 = new(rawData, (string)null, options.KeyStorageFlags);
                    return Response.FromValue(x509, secretResponse.GetRawResponse());
                }
                else if (secret.ContentType == CertificateContentType.Pem)
                {
                    X509Certificate2 x509 = PemReader.LoadCertificate(value.AsSpan(), certificate.Cer, allowCertificateOnly: true, keyStorageFlags: options.KeyStorageFlags);
                    return Response.FromValue(x509, secretResponse.GetRawResponse());
                }

                throw new NotSupportedException($"Content type {secret.ContentType} not supported");
            }
            catch (Exception e)
            {
                scope.Failed(e);
                throw;
            }
```

This PR fixes that and allows `CertificateClient.DownloadCertificate{Async}` to function as expected, providing the `X509Certificate2?` response that's expected instead of throwing a cryptographic error.

## Issue ticket number and link

* Fixes: #263 

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have ran the test suite locally to ensure no breaking changes have been added.
- [x] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [x] I have added new tests, if applicable.