### PR TITLE
Azure DevOps now detected as part of TestContainers launch (#272)

### DIFF
--- a/src/TestContainers/dotnet/Helpers/AzureKeyVaultEnvHelper.cs
+++ b/src/TestContainers/dotnet/Helpers/AzureKeyVaultEnvHelper.cs
@@ -5,6 +5,13 @@ namespace AzureKeyVaultEmulator.TestContainers.Helpers;
 
 internal static class AzureKeyVaultEnvHelper
 {
+    private static readonly string[] _defaultVars =
+    [
+        "BUILD_BUILDID", // Azure DevOps
+        "CI", // Jekyll, TeamCity, etc
+        "GITHUB_ACTIONS" // Github, obviously.
+    ];
+
     public static void Bash(string command)
     {
         var psi = new ProcessStartInfo
@@ -40,8 +47,6 @@ internal static class AzureKeyVaultEnvHelper
     /// <returns></returns>
     public static bool IsCiCdEnvironment()
     {
-        var ci = Environment.GetEnvironmentVariable("CI")?.ToLowerInvariant();
-        var gh = Environment.GetEnvironmentVariable("GITHUB_ACTIONS");
-        return ci == "true" || gh == "true";
+        return _defaultVars.Any(env => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(env)));
     }
 }


### PR DESCRIPTION
## Describe your changes

Finds the default `BUILD_BUILDID` variable from an Azure DevOps CI/CD pipeline to detect a pipeline run, enforcing `/tmp/` certificate installation correctly.

## Issue ticket number and link

* Fixes: #272

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have ran the test suite locally to ensure no breaking changes have been added.
- [x] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [x] I have added new tests, if applicable.