### PR TITLE
Fixed automated Docker script URL in README

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,4 +1,4 @@
 > [!IMPORTANT]
 > As of `10/29/2024` [Basis Theory](https://github.com/Basis-Theory/azure-keyvault-emulator) is no longer maintaining the base repository, although the development seemed to be ceased for quite some time prior to that. Due to the ever-growing popularity of `.NET Aspire` the emulator is becoming increasingly more important; I've forked the repository with the goal to create a feature-complete, `.NET Aspire` supported emulator. <br /><br />
-> This repo has been detactched from the base repo as of `22/03/2025` due to the change in direction and aspirations for the project., but I cannot thank Basis Theory enough for the original codebase.
+> This repo has been detached from the base repo as of `22/03/2025` due to the change in direction and aspirations for the project., but I cannot thank Basis Theory enough for the original codebase.
 > The original license holder retains their copyright to all original source code, additions or changes beyond [this commit](https://github.com/james-gould/azure-keyvault-emulator/commit/5a9bbb94ca7f52755144fd20d7966575530e0275) are now held by James Gould, the author.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can find [sample applications here](https://github.com/james-gould/azure-key
 The setup process can be fully automated by using the installation script:
 
 ```
-bash <(curl -fsSL https://github.com/james-gould/azure-keyvault-emulator/blob/master/docs/setup.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/james-gould/azure-keyvault-emulator/refs/heads/master/docs/setup.sh)
 ```
 
 > [!IMPORTANT]

--- a/docs/CertificateUtilities/README.md
+++ b/docs/CertificateUtilities/README.md
@@ -12,7 +12,7 @@ The `AzureKeyVaultEmulator.Aspire.Hosting` library will generate and install the
 The setup process can be fully automated by using the installation script:
 
 ```
-bash <(curl -fsSL https://github.com/james-gould/azure-keyvault-emulator/blob/master/docs/setup.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/james-gould/azure-keyvault-emulator/refs/heads/master/docs/setup.sh)
 ```
 
 > [!IMPORTANT]

--- a/src/TestContainers/dotnet/README.md
+++ b/src/TestContainers/dotnet/README.md
@@ -28,7 +28,7 @@ dotnet add package AzureKeyVaultEmulator.TestContainers
 
 ## SSL Usage
 
-The Azure SDK **requires** a trusted SSL connection to use the official clients. To make this as smooth as possible, the following functionality is turned **on** by default:
+The Azure SDK **requires** a trusted SSL connection to use the official clients. To make this as smooth as possible, the following functionality is turned **on** by default and is **fully automated**:
 
 - Generate the required SSL certificates
 - Install them to the `User` store location as a `Trusted Root CA`


### PR DESCRIPTION
## Describe your changes

After removing the custom domain and replacing with the `github.com...` URL, the `setup.sh` script doesn't load due to GH's redirect unless specifying `raw.githubusercontent`.

Updated all references to the script, probably.