### PR TITLE
Handle switching to dotnet dev-certs better

### DIFF
--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/Constants/KeyVaultEmulatorCertConstants.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/Constants/KeyVaultEmulatorCertConstants.cs
@@ -6,6 +6,7 @@ public sealed class KeyVaultEmulatorCertConstants
 
     public const string HostParentDirectory = "keyvaultemulator";
     public const string HostChildDirectory = "certs";
+    public const string HostDotnetDevCertsChildDirectory = "dotnet-dev-certs";
 
     // PFX is referenced in the Dockerfile, update both is this changes.
     public const string Pfx = $"{_rootName}.pfx";


### PR DESCRIPTION
## Describe your changes

In this change, the dotnet dev-certs are persisted in a different folder than the ones generated by this emulator by default. This way, the dev-certs and custom certs will have their own folder and will be able to live side by side on the same dev machine.

Also cleanup obsolete comment in `InstallViaDotnetDevCerts` + used the constants for the password.

## Issue ticket number and link

* Fixes: #301

## Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] I have ran the test suite locally to ensure no breaking changes have been added.
- [ ] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [ ] I have added new tests, if applicable.