### PR TITLE
vaultUri now being set before ResourceReadyEvent is raised

### DIFF
--- a/dev/AzureKeyVaultEmulator.AppHost/AzureKeyVaultEmulator.AppHost.AppHost/AzureKeyVaultEmulator.AppHost.csproj
+++ b/dev/AzureKeyVaultEmulator.AppHost/AzureKeyVaultEmulator.AppHost.AppHost/AzureKeyVaultEmulator.AppHost.csproj
@@ -10,8 +10,8 @@
     <IsAspireHost>true</IsAspireHost>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.3.1" />
-    <PackageReference Include="Aspire.Hosting.Azure.KeyVault" Version="9.3.1" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.4.0" />
+    <PackageReference Include="Aspire.Hosting.Azure.KeyVault" Version="9.4.0" />
     <PackageReference Include="WireMock.Net" Version="1.8.17" />
   </ItemGroup>
   <ItemGroup>

--- a/dev/AzureKeyVaultEmulator.AppHost/AzureKeyVaultEmulator.AppHost.AppHost/Program.cs
+++ b/dev/AzureKeyVaultEmulator.AppHost/AzureKeyVaultEmulator.AppHost.AppHost/Program.cs
@@ -12,7 +12,7 @@ var keyVault = builder
     .RunAsEmulator(
         new KeyVaultEmulatorOptions
         {
-            UseDotnetDevCerts = (isWiremockTestRunning && OperatingSystem.IsLinux())
+            UseDotnetDevCerts = isWiremockTestRunning
             //Lifetime = ContainerLifetime.Persistent
         }
     );

--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorExtensions.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorExtensions.cs
@@ -126,6 +126,8 @@ namespace AzureKeyVaultEmulator.Aspire.Hosting
                 var allocatedEndpoint = endpoint.AllocatedEndpoint?.UriString
                     ?? throw new KeyVaultEmulatorException("Failed to locate host machine port for allocated Emulator container.");
 
+                builder.Resource.Outputs.Clear();
+
                 builder.Resource.Outputs.Add("vaultUri", allocatedEndpoint);
                 builder.WithUrl(allocatedEndpoint, allocatedEndpoint);
 
@@ -135,6 +137,8 @@ namespace AzureKeyVaultEmulator.Aspire.Hosting
             });
 
             builder.RegisterOptionalLifecycleHandler(() => _allocatedEndpoint, options, hostCertificatePath);
+
+            builder.Resource.Outputs.Add("vaultUri", "https://localhost:4998");
 
             return builder;
         }

--- a/test/AzureKeyVaultEmulator.IntegrationTests/AzureKeyVaultEmulator.IntegrationTests.csproj
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/AzureKeyVaultEmulator.IntegrationTests.csproj
@@ -8,24 +8,27 @@
     <UserSecretsId>1f5e0e4e-442f-475f-8662-94a562031d22</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Testing" Version="9.3.1" />
+    <PackageReference Include="Aspire.Hosting.Testing" Version="9.4.0" />
     <PackageReference Include="Asp.Versioning.Http" Version="8.1.0" />
     <PackageReference Include="Asp.Versioning.Http.Client" Version="8.1.0" />
-    <PackageReference Include="Azure.Identity" Version="1.14.1" />
+    <PackageReference Include="Azure.Identity" Version="1.14.2" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.8.0" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.8.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     
-    <PackageReference Include="xunit.analyzers" Version="1.22.0">
+    <PackageReference Include="xunit.analyzers" Version="1.23.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit.core" Version="2.9.3" />
     <PackageReference Include="xunit.assert.source" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Using Include="System.Net" />
@@ -36,6 +39,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\dev\AzureKeyVaultEmulator.AppHost\AzureKeyVaultEmulator.AppHost.AppHost\AzureKeyVaultEmulator.AppHost.csproj" />
-    <ProjectReference Include="..\..\src\AzureKeyVaultEmulator.Shared\AzureKeyVaultEmulator.Shared.csproj" IsAspireProjectResource="false"/>
+    <ProjectReference Include="..\..\src\AzureKeyVaultEmulator.Shared\AzureKeyVaultEmulator.Shared.csproj" IsAspireProjectResource="false" />
   </ItemGroup>
 </Project>

--- a/test/AzureKeyVaultEmulator.TestContainers.Tests/AzureKeyVaultEmulator.TestContainers.Tests.csproj
+++ b/test/AzureKeyVaultEmulator.TestContainers.Tests/AzureKeyVaultEmulator.TestContainers.Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/AzureKeyVaultEmulator.Wiremock.IntegrationTests/AzureKeyVaultEmulator.Wiremock.IntegrationTests.csproj
+++ b/test/AzureKeyVaultEmulator.Wiremock.IntegrationTests/AzureKeyVaultEmulator.Wiremock.IntegrationTests.csproj
@@ -9,11 +9,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Testing" Version="9.3.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Aspire.Hosting.Testing" Version="9.4.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Describe your changes

Constructs the required `vaultUri` ahead of a `ResourceReadyEvent` being raised by `Aspire`. Some Bicep logic reworking has caused this to fail earlier when upgrading to `v9.4` which is now resolved.

Upon inspection the port is always exposed as `4997` however, which conflicts with the fix applied for #281 - only one endpoint is allocated for the container which is `https://localhost:4997` whereas before it would provide a host port address in the `4-6xxx` range.

## Issue ticket number and link

* Fixes: #304 

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have ran the test suite locally to ensure no breaking changes have been added.
- [x] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [x] I have added new tests, if applicable.