### PR TITLE
Imported certificates now set their content type correctly

### DIFF
--- a/src/AzureKeyVaultEmulator/Certificates/Factories/X509CertificateFactory.cs
+++ b/src/AzureKeyVaultEmulator/Certificates/Factories/X509CertificateFactory.cs
@@ -90,7 +90,7 @@ public static class X509CertificateFactory
     public static string ParseContentType(this X509ContentType contentType) => contentType switch
     {
         X509ContentType.Pfx => "application/x-pkcs12",
-        X509ContentType.Pkcs7 => "application/x-pem-file",
+        X509ContentType.Cert => "application/x-pem-file",
 
         _ => throw new InvalidOperationException($"Certificate content type {contentType} is not supported.")
     };

--- a/src/AzureKeyVaultEmulator/Certificates/Factories/X509CertificateFactory.cs
+++ b/src/AzureKeyVaultEmulator/Certificates/Factories/X509CertificateFactory.cs
@@ -61,12 +61,39 @@ public static class X509CertificateFactory
         return baseCert;
     }
 
-    public static X509Certificate2 ImportFromBase64(string certificateBase64)
+    public static X509Certificate2 ImportFromBase64(byte[] rawCert, string? password = null)
     {
-        ArgumentException.ThrowIfNullOrEmpty(certificateBase64);
+        ArgumentNullException.ThrowIfNull(rawCert);
 
-        return X509CertificateLoader.LoadCertificate(Convert.FromBase64String(certificateBase64));
+        if (rawCert.Length == 0)
+            throw new InvalidOperationException($"Cannot import empty certificate bytes");
+
+        try
+        {
+            // PFX
+            return X509CertificateLoader.LoadCertificate(rawCert);
+        }
+        catch { }
+
+        // Failure might happen due to password being required, now we should validate it's not null and use it.
+        ArgumentNullException.ThrowIfNull(password);
+
+        try
+        {
+            return X509CertificateLoader.LoadPkcs12(rawCert, password, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.DefaultKeySet);
+        }
+        catch { }
+
+        throw new InvalidOperationException($"Failed to import certificate due to incompatible type.");
     }
+
+    public static string ParseContentType(this X509ContentType contentType) => contentType switch
+    {
+        X509ContentType.Pfx => "application/x-pkcs12",
+        X509ContentType.Pkcs7 => "application/x-pem-file",
+
+        _ => throw new InvalidOperationException($"Certificate content type {contentType} is not supported.")
+    };
 
     private static X509Extension? BuildSubjectAlternativeName(this CertificatePolicy? policy)
     {

--- a/src/AzureKeyVaultEmulator/Certificates/Services/CertificateBackingService.cs
+++ b/src/AzureKeyVaultEmulator/Certificates/Services/CertificateBackingService.cs
@@ -178,13 +178,11 @@ public sealed class CertificateBackingService(
     {
         var certificateData = Convert.ToBase64String(certificate.Export(contentType, certificatePassword));
 
-        var parsedContentType = contentType.ParseContentType();
-
         return await secretService
             .SetSecretAsync(certName, new SetSecretRequest
             {
                 Value = certificateData,
-                SecretAttributes = new() { ContentType = parsedContentType }
+                SecretAttributes = new() { ContentType = contentType.ParseContentType() }
             });
     }
 }

--- a/src/AzureKeyVaultEmulator/Certificates/Services/CertificateBackingService.cs
+++ b/src/AzureKeyVaultEmulator/Certificates/Services/CertificateBackingService.cs
@@ -178,11 +178,13 @@ public sealed class CertificateBackingService(
     {
         var certificateData = Convert.ToBase64String(certificate.Export(contentType, certificatePassword));
 
+        var parsedContentType = contentType.ParseContentType();
+
         return await secretService
             .SetSecretAsync(certName, new SetSecretRequest
             {
                 Value = certificateData,
-                SecretAttributes = new() { ContentType = contentType.ParseContentType() }
+                SecretAttributes = new() { ContentType = parsedContentType }
             });
     }
 }

--- a/src/AzureKeyVaultEmulator/Certificates/Services/ICertificateBackingService.cs
+++ b/src/AzureKeyVaultEmulator/Certificates/Services/ICertificateBackingService.cs
@@ -7,7 +7,7 @@ namespace AzureKeyVaultEmulator.Certificates.Services;
 
 public interface ICertificateBackingService
 {
-    Task<(KeyBundle backingKey, SecretBundle backingSecret)> GetBackingComponentsAsync(string certName, X509Certificate2? cert, CertificatePolicy? policy = null);
+    Task<(KeyBundle backingKey, SecretBundle backingSecret)> GetBackingComponentsAsync(string certName, X509Certificate2? cert, string? password = null, CertificatePolicy? policy = null, X509ContentType contentType = X509ContentType.Pfx);
 
     Task<IssuerBundle> GetIssuerAsync(string name);
     Task<IssuerBundle> CreateIssuerAsync(string name, IssuerBundle bundle);

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/CertificateManagementTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/CertificateManagementTests.cs
@@ -42,11 +42,68 @@ public class CertificateManagementTests(CertificatesTestingFixture fixture) : IC
 
         var x509 = CreateCertificate(certName);
 
-        var exportedFromRaw = x509.Export(X509ContentType.Pkcs12, certPwd);
+        var exportedToRaw = x509.Export(X509ContentType.Pkcs12, certPwd);
 
-        var options = new ImportCertificateOptions(certName, exportedFromRaw)
+        var options = new ImportCertificateOptions(certName, exportedToRaw)
         {
             Password = certPwd,
+        };
+
+        var importResponse = await client.ImportCertificateAsync(options);
+
+        var importedCertificate = importResponse.Value;
+
+        Assert.NotNull(importedCertificate);
+        Assert.Equal(certName, importedCertificate.Name);
+        Assert.Equal(expectedContentType, importedCertificate.Policy.ContentType);
+    }
+
+    [Fact]
+    public async Task ImportingPemCertificateWillSucceed()
+    {
+        var client = await fixture.GetClientAsync();
+
+        var certName = fixture.FreshlyGeneratedGuid;
+        var certPwd = fixture.FreshlyGeneratedGuid;
+
+        var x509 = CreateCertificate(certName);
+
+        var pem = x509.ExportCertificatePem();
+
+        var exportedToRaw = Encoding.UTF8.GetBytes(pem);
+
+        var options = new ImportCertificateOptions(certName, exportedToRaw)
+        {
+            Password = certPwd
+        };
+
+        var importResponse = await client.ImportCertificateAsync(options);
+
+        var importedCertificate = importResponse.Value;
+
+        Assert.NotNull(importedCertificate);
+        Assert.Equal(certName, importedCertificate.Name);
+    }
+
+    [Fact]
+    public async Task ImportingPemCertificateWillCorrectContentType()
+    {
+        var client = await fixture.GetClientAsync();
+
+        var certName = fixture.FreshlyGeneratedGuid;
+        var certPwd = fixture.FreshlyGeneratedGuid;
+
+        var expectedContentType = "application/x-pem-file";
+
+        var x509 = CreateCertificate(certName);
+
+        var pem = x509.ExportCertificatePem();
+
+        var exportedToRaw = Encoding.UTF8.GetBytes(pem);
+
+        var options = new ImportCertificateOptions(certName, exportedToRaw)
+        {
+            Password = certPwd
         };
 
         var importResponse = await client.ImportCertificateAsync(options);

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/CertificateManagementTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/CertificateManagementTests.cs
@@ -1,0 +1,81 @@
+﻿using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Azure.Security.KeyVault.Certificates;
+using AzureKeyVaultEmulator.IntegrationTests.SetupHelper.Fixtures;
+
+namespace AzureKeyVaultEmulator.IntegrationTests.Certificates;
+
+public class CertificateManagementTests(CertificatesTestingFixture fixture) : IClassFixture<CertificatesTestingFixture>
+{
+    [Fact]
+    public async Task ImportingP12CertificateWillSucceed()
+    {
+        var client = await fixture.GetClientAsync();
+
+        var certName = fixture.FreshlyGeneratedGuid;
+        var certPwd = fixture.FreshlyGeneratedGuid;
+
+        var x509 = CreateCertificate(certName);
+
+        var exportedFromRaw = x509.Export(X509ContentType.Pkcs12, certPwd);
+
+        var options = new ImportCertificateOptions(certName, exportedFromRaw)
+        {
+            Password = certPwd,
+        };
+
+        var importedCertificate = await client.ImportCertificateAsync(options);
+
+        Assert.NotNull(importedCertificate.Value);
+        Assert.Equal(certName, importedCertificate.Value.Name);
+    }
+
+    [Fact]
+    public async Task ImportingP12CertificateWillSetCorrectContentType()
+    {
+        var client = await fixture.GetClientAsync();
+
+        var expectedContentType = "application/x-pkcs12";
+
+        var certName = fixture.FreshlyGeneratedGuid;
+        var certPwd = fixture.FreshlyGeneratedGuid;
+
+        var x509 = CreateCertificate(certName);
+
+        var exportedFromRaw = x509.Export(X509ContentType.Pkcs12, certPwd);
+
+        var options = new ImportCertificateOptions(certName, exportedFromRaw)
+        {
+            Password = certPwd,
+        };
+
+        var importResponse = await client.ImportCertificateAsync(options);
+
+        var importedCertificate = importResponse.Value;
+
+        Assert.NotNull(importedCertificate);
+        Assert.Equal(certName, importedCertificate.Name);
+        Assert.Equal(expectedContentType, importedCertificate.Policy.ContentType);
+    }
+
+    private static X509Certificate2 CreateCertificate(string name)
+    {
+        var keySize = 2048;
+
+        using var rsa = RSA.Create(keySize);
+
+        var certName = new X500DistinguishedName($"CN={name}");
+
+        var request = new CertificateRequest(certName, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+        request.CertificateExtensions
+            .Add(new X509KeyUsageExtension(
+                X509KeyUsageFlags.DataEncipherment |
+                X509KeyUsageFlags.KeyEncipherment |
+                X509KeyUsageFlags.DigitalSignature,
+                false)
+            );
+
+        return request.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now.AddDays(365));
+    }
+}


### PR DESCRIPTION
## Describe your changes

Certificates being imported, or created, will now set their content type correctly based on the format. The following support has been added to [mirror Azure Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/certificates/certificate-scenarios#import-a-certificate):

- `PEM` - `application/x-pem-file`
- `PFX` and `P12`- `application/x-pkcs12`

The content type will be set within the `CertificatePolicy`: `importedCertificate.Policy.ContentType`, and converting to an `x509Certificate2` will resolve `convertedCertificate.GetCertContentType()` correctly too.

## Issue ticket number and link

* #337 
* #336 

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have ran the test suite locally to ensure no breaking changes have been added.
- [x] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [x] I have added new tests, if applicable.