### PR TITLE
ARM64 containers are now built, pushed and used automatically if required

### DIFF
--- a/.github/workflows/publish-all-manual.yml
+++ b/.github/workflows/publish-all-manual.yml
@@ -67,8 +67,18 @@ jobs:
         run: |
           docker build -t jamesgoulddev/azure-keyvault-emulator:latest -t jamesgoulddev/azure-keyvault-emulator:${{ env.VERSION }} .
 
+      - name: Build Docker Image
+        run: |
+          docker build --platform linux/arm64/v8 -t jamesgoulddev/azure-keyvault-emulator:latest-arm -t jamesgoulddev/azure-keyvault-emulator:${{ env.VERSION }}-arm .
+
       - name: Push Latest Docker Image
         run: docker push jamesgoulddev/azure-keyvault-emulator:latest
 
       - name: Push Versioned Docker Image
         run: docker push jamesgoulddev/azure-keyvault-emulator:${{ env.VERSION }}
+
+      - name: Push Latest Docker Image (ARM64)
+        run: docker push jamesgoulddev/azure-keyvault-emulator:latest-arm
+
+      - name: Push Versioned Docker Image (ARM64)
+        run: docker push jamesgoulddev/azure-keyvault-emulator:${{ env.VERSION }}-arm

--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/Constants/KeyVaultEmulatorContainerConstants.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/Constants/KeyVaultEmulatorContainerConstants.cs
@@ -8,7 +8,7 @@
         public const string Image = "jamesgoulddev/azure-keyvault-emulator";
         public const int Port = 4997;
 
-        public const string Tag = "2.5.7";
+        public const string Tag = "2.5.8";
         public static string ArmTag => $"{Tag}-arm";
 
     }

--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/Constants/KeyVaultEmulatorContainerConstants.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/Constants/KeyVaultEmulatorContainerConstants.cs
@@ -15,13 +15,6 @@
 
     internal partial class KeyVaultEmulatorContainerConstants
     {
-        // Connection related
-
-        public const string Endpoint = "https://localhost:4997";
-    }
-
-    internal partial class KeyVaultEmulatorContainerConstants
-    {
         // Environment Variables
 
         public const string PersistData = "Persist";

--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/Constants/KeyVaultEmulatorContainerConstants.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/Constants/KeyVaultEmulatorContainerConstants.cs
@@ -9,6 +9,7 @@
         public const int Port = 4997;
 
         public const string Tag = "2.5.7";
+        public static string ArmTag => $"{Tag}-arm";
 
     }
 

--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/Helpers/AzureKeyVaultEnvHelper.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/Helpers/AzureKeyVaultEnvHelper.cs
@@ -1,5 +1,6 @@
 using AzureKeyVaultEmulator.Aspire.Hosting.Exceptions;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace AzureKeyVaultEmulator.Aspire.Hosting.Helpers;
 
@@ -55,7 +56,15 @@ internal static class AzureKeyVaultEnvHelper
     /// </summary>
     /// <returns></returns>
     public static bool IsCiCdEnvironment()
-    {
-        return _defaultVars.Any(env => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(env)));
-    }
+        => _defaultVars.Any(env => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(env)));
+
+    /// <summary>
+    /// <para>Determines the appropriate container tag based off the current process architecture.</para>
+    /// <para>linx/arm64/v8 images are built alongside amd64 images, see issue #338</para>
+    /// </summary>
+    /// <returns>The container tag to use for the Emulator.</returns>
+    public static string GetContainerTag()
+        => RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? KeyVaultEmulatorContainerConstants.ArmTag
+                : KeyVaultEmulatorContainerConstants.Tag;
 }

--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorExtensions.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorExtensions.cs
@@ -81,10 +81,12 @@ namespace AzureKeyVaultEmulator.Aspire.Hosting
 
             ArgumentException.ThrowIfNullOrEmpty(hostCertificatePath);
 
+            var containerTag = AzureKeyVaultEnvHelper.GetContainerTag();
+
             var keyVaultResourceBuilder = builder.ApplicationBuilder.CreateResourceBuilder(new AzureKeyVaultEmulatorResource(builder.Resource))
                    .WithImage(KeyVaultEmulatorContainerConstants.Image)
                    .WithImageRegistry(KeyVaultEmulatorContainerConstants.Registry)
-                   .WithImageTag(KeyVaultEmulatorContainerConstants.Tag)
+                   .WithImageTag(containerTag)
                    .WithBindMount(
                         source: hostCertificatePath,
                         target: KeyVaultEmulatorCertConstants.CertMountTarget)

--- a/src/TestContainers/dotnet/AzureKeyVaultEmulatorContainer.cs
+++ b/src/TestContainers/dotnet/AzureKeyVaultEmulatorContainer.cs
@@ -45,8 +45,10 @@ public sealed class AzureKeyVaultEmulatorContainer : IAsyncDisposable, IDisposab
         if (_options.LoadCertificatesIntoTrustStore)
             AzureKeyVaultEmulatorCertHelper.TryWriteToStore(_options, _loadedCertificates.Pfx, _loadedCertificates.LocalCertificatePath, _loadedCertificates.pem);
 
+        var containerTag = AzureKeyVaultEnvHelper.GetContainerTag();
+
         _container = new ContainerBuilder()
-            .WithImage($"{AzureKeyVaultEmulatorContainerConstants.Registry}/{AzureKeyVaultEmulatorContainerConstants.Image}:{_options.Tag ?? AzureKeyVaultEmulatorContainerConstants.Tag}")
+            .WithImage($"{AzureKeyVaultEmulatorContainerConstants.Registry}/{AzureKeyVaultEmulatorContainerConstants.Image}:{_options.Tag ?? containerTag}")
             .WithPortBinding(AzureKeyVaultEmulatorContainerConstants.Port, false)
             .WithBindMount(_options.LocalCertificatePath, AzureKeyVaultEmulatorCertConstants.CertMountTarget)
             .WithEnvironment(AzureKeyVaultEmulatorContainerConstants.PersistData, $"{_options.Persist}")

--- a/src/TestContainers/dotnet/Constants/AzureKeyVaultEmulatorContainerConstants.cs
+++ b/src/TestContainers/dotnet/Constants/AzureKeyVaultEmulatorContainerConstants.cs
@@ -14,13 +14,6 @@ internal partial class AzureKeyVaultEmulatorContainerConstants
 
 internal partial class AzureKeyVaultEmulatorContainerConstants
 {
-    // Connection related
-
-    public const string Endpoint = "https://localhost:4997";
-}
-
-internal partial class AzureKeyVaultEmulatorContainerConstants
-{
     // Environment Variables
 
     public const string PersistData = "Persist";

--- a/src/TestContainers/dotnet/Constants/AzureKeyVaultEmulatorContainerConstants.cs
+++ b/src/TestContainers/dotnet/Constants/AzureKeyVaultEmulatorContainerConstants.cs
@@ -9,6 +9,7 @@ internal partial class AzureKeyVaultEmulatorContainerConstants
     public const int Port = 4997;
 
     public const string Tag = "2.5.7";
+    public static string ArmTag => $"{Tag}-arm";
 }
 
 internal partial class AzureKeyVaultEmulatorContainerConstants

--- a/src/TestContainers/dotnet/Constants/AzureKeyVaultEmulatorContainerConstants.cs
+++ b/src/TestContainers/dotnet/Constants/AzureKeyVaultEmulatorContainerConstants.cs
@@ -8,7 +8,7 @@ internal partial class AzureKeyVaultEmulatorContainerConstants
     public const string Image = "jamesgoulddev/azure-keyvault-emulator";
     public const int Port = 4997;
 
-    public const string Tag = "2.5.7";
+    public const string Tag = "2.5.8";
     public static string ArmTag => $"{Tag}-arm";
 }
 

--- a/src/TestContainers/dotnet/Helpers/AzureKeyVaultEnvHelper.cs
+++ b/src/TestContainers/dotnet/Helpers/AzureKeyVaultEnvHelper.cs
@@ -1,5 +1,7 @@
-using AzureKeyVaultEmulator.TestContainers.Exceptions;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
+using AzureKeyVaultEmulator.TestContainers.Constants;
+using AzureKeyVaultEmulator.TestContainers.Exceptions;
 
 namespace AzureKeyVaultEmulator.TestContainers.Helpers;
 
@@ -46,7 +48,15 @@ internal static class AzureKeyVaultEnvHelper
     /// </summary>
     /// <returns></returns>
     public static bool IsCiCdEnvironment()
-    {
-        return _defaultVars.Any(env => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(env)));
-    }
+        => _defaultVars.Any(env => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(env)));
+
+    /// <summary>
+    /// <para>Determines the appropriate container tag based off the current process architecture.</para>
+    /// <para>linx/arm64/v8 images are built alongside amd64 images, see issue #338</para>
+    /// </summary>
+    /// <returns>The container tag to use for the Emulator.</returns>
+    public static string GetContainerTag()
+        => RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? AzureKeyVaultEmulatorContainerConstants.ArmTag
+                : AzureKeyVaultEmulatorContainerConstants.Tag;
 }


### PR DESCRIPTION
## Describe your changes

Building an aditional container image using `--platform linux/arm64/v8` specified allows M1 chip/arm64 architecture CPUs to run the emulator without issue. This has been added to the `Action` for deploying a new version of the Emulator, along with architecture detection and tag switching automatically.

## Issue ticket number and link

* Fixes: #338 

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have ran the test suite locally to ensure no breaking changes have been added.
- [x] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [x] I have added new tests, if applicable.