### PR TITLE
Cyclical integration tests reenabled for Github Action running

### DIFF
--- a/dev/AzureKeyVaultEmulator.AppHost/AzureKeyVaultEmulator.AppHost.AppHost/Program.cs
+++ b/dev/AzureKeyVaultEmulator.AppHost/AzureKeyVaultEmulator.AppHost.AppHost/Program.cs
@@ -23,7 +23,7 @@ var keyVault = builder
 
 var webApi = builder
     .AddProject<Projects.WebApiWithEmulator_DebugHelper>(AspireConstants.DebugHelper)
-    //.WithEnvironment($"ConnectionStrings__{AspireConstants.EmulatorServiceName}", keyVault.GetEndpoint("https"))
+    .WithEnvironment($"ConnectionStrings__{AspireConstants.EmulatorServiceName}", keyVault.GetEndpoint("https"))
     .WithReference(keyVault)
     .WaitFor(keyVault);
 

--- a/dev/AzureKeyVaultEmulator.AppHost/AzureKeyVaultEmulator.AppHost.AppHost/Program.cs
+++ b/dev/AzureKeyVaultEmulator.AppHost/AzureKeyVaultEmulator.AppHost.AppHost/Program.cs
@@ -23,7 +23,7 @@ var keyVault = builder
 
 var webApi = builder
     .AddProject<Projects.WebApiWithEmulator_DebugHelper>(AspireConstants.DebugHelper)
-    .WithEnvironment($"ConnectionStrings__{AspireConstants.EmulatorServiceName}", keyVault.GetEndpoint("https"))
+    //.WithEnvironment($"ConnectionStrings__{AspireConstants.EmulatorServiceName}", keyVault.GetEndpoint("https"))
     .WithReference(keyVault)
     .WaitFor(keyVault);
 

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/CertificatesControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/CertificatesControllerTests.cs
@@ -391,7 +391,8 @@ public class CertificatesControllerTests(CertificatesTestingFixture fixture)
         Assert.CertificatesAreEqual(cert, restoredCert);
     }
 
-    [Fact(Skip = "Cyclical tests randomly failing on Github, issue #145")]
+    //[Fact(Skip = "Cyclical tests randomly failing on Github, issue #145")]
+    [Fact]
     public async Task GetCertificateVersionsListWillCycleLink()
     {
         var client = await fixture.GetClientAsync();
@@ -409,7 +410,8 @@ public class CertificatesControllerTests(CertificatesTestingFixture fixture)
         Assert.Equal(executionCount, certs.Count);
     }
 
-    [Fact(Skip = "Cyclical tests randomly failing on Github, issue #145")]
+    //[Fact(Skip = "Cyclical tests randomly failing on Github, issue #145")]
+    [Fact]
     public async Task GetCertificatesListWillCycleLink()
     {
         var client = await fixture.GetClientAsync();

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/CertificatesControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/CertificatesControllerTests.cs
@@ -399,7 +399,7 @@ public class CertificatesControllerTests(CertificatesTestingFixture fixture)
         var certName = fixture.FreshlyGeneratedGuid;
 
         var executionCount = await RequestSetup
-            .CreateMultiple(26, 51, i => fixture.CreateCertificateAsync(certName));
+            .CreateMultiple(26, 30, i => fixture.CreateCertificateAsync(certName));
 
         List<CertificateProperties> certs = [];
 
@@ -417,7 +417,7 @@ public class CertificatesControllerTests(CertificatesTestingFixture fixture)
         var certName = fixture.FreshlyGeneratedGuid;
 
         var executionCount = await RequestSetup
-            .CreateMultiple(26, 51, i => fixture.CreateCertificateAsync(certName));
+            .CreateMultiple(26, 30, i => fixture.CreateCertificateAsync(certName));
 
         List<CertificateProperties> certs = [];
 
@@ -429,7 +429,6 @@ public class CertificatesControllerTests(CertificatesTestingFixture fixture)
         Assert.NotEmpty(certs);
     }
 
-    //[Fact(Skip = "404 issue from CertificateClient again, underlying endpoint/functionality works fine. See iss #106")]
     [Fact]
     public async Task ImportingCertificateWillPersistInStore()
     {

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/DeletedCertificatesControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/DeletedCertificatesControllerTests.cs
@@ -28,7 +28,7 @@ public class DeletedCertificatesControllerTests(CertificatesTestingFixture fixtu
         var name = fixture.FreshlyGeneratedGuid;
 
         var executionCount = await RequestSetup
-            .CreateMultiple(26, 51, i => fixture.CreateCertificateAsync(name));
+            .CreateMultiple(26, 30, i => fixture.CreateCertificateAsync(name));
 
         var deleteOp = await client.StartDeleteCertificateAsync(name);
 

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/DeletedCertificatesControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/DeletedCertificatesControllerTests.cs
@@ -20,7 +20,8 @@ public class DeletedCertificatesControllerTests(CertificatesTestingFixture fixtu
         Assert.Equal(certName, deletedCert.Value.Name);
     }
 
-    [Fact(Skip = "Cyclical tests randomly failing on Github, issue #145")]
+    //[Fact(Skip = "Cyclical tests randomly failing on Github, issue #145")]
+    [Fact]
     public async Task GetDeletedCertificatesWillCycleLink()
     {
         var client = await fixture.GetClientAsync();

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/DeletedCertificatesControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/DeletedCertificatesControllerTests.cs
@@ -43,9 +43,7 @@ public class DeletedCertificatesControllerTests(CertificatesTestingFixture fixtu
             if(certificate.Name.Contains(name))
                 deletedCerts.Add(certificate);
 
-        // All versions are deleted with just one preserved.
-        // When restoring only one version, the latest, should be restored
-        Assert.Single(deletedCerts);
+        Assert.Equal(executionCount, deletedCerts.Count);
     }
 
     [Fact]

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Keys/DeletedKeysControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Keys/DeletedKeysControllerTests.cs
@@ -24,7 +24,8 @@ public sealed class DeletedKeysControllerTests(KeysTestingFixture fixture) : ICl
         Assert.KeysAreEqual(createdKey, deletedKey);
     }
 
-    [Fact(Skip = "Cyclical tests randomly failing on Github, issue #145")]
+    //[Fact(Skip = "Cyclical tests randomly failing on Github, issue #145")]
+    [Fact]
     public async Task GetDeletedKeysWillCycleLink()
     {
         var client = await fixture.GetClientAsync();

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Keys/DeletedKeysControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Keys/DeletedKeysControllerTests.cs
@@ -32,7 +32,7 @@ public sealed class DeletedKeysControllerTests(KeysTestingFixture fixture) : ICl
         var keyName = fixture.FreshlyGeneratedGuid;
 
         var executionCount = await
-            RequestSetup.CreateMultiple(26, 51, y => client.CreateKeyAsync(keyName, KeyType.Rsa));
+            RequestSetup.CreateMultiple(26, 30, y => client.CreateKeyAsync(keyName, KeyType.Rsa));
 
         var deleteOperation = (await client.StartDeleteKeyAsync(keyName)).Value;
 

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Keys/KeysControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Keys/KeysControllerTests.cs
@@ -149,7 +149,7 @@ public sealed class KeysControllerTests(KeysTestingFixture fixture) : IClassFixt
         var keyName = fixture.FreshlyGeneratedGuid;
 
         var executionCount = await RequestSetup
-            .CreateMultiple(26, 51, i => client.CreateKeyAsync(keyName, KeyType.Rsa));
+            .CreateMultiple(26, 30, i => client.CreateKeyAsync(keyName, KeyType.Rsa));
 
         List<string> matchingKeys = [];
 
@@ -168,7 +168,7 @@ public sealed class KeysControllerTests(KeysTestingFixture fixture) : IClassFixt
         var keyName = fixture.FreshlyGeneratedGuid;
 
         var executionCount = await RequestSetup
-            .CreateMultiple(26, 51, i => client.CreateKeyAsync(keyName, KeyType.Rsa));
+            .CreateMultiple(26, 30, i => client.CreateKeyAsync(keyName, KeyType.Rsa));
 
         List<string> matchingKeys = [];
 

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Keys/KeysControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Keys/KeysControllerTests.cs
@@ -141,7 +141,8 @@ public sealed class KeysControllerTests(KeysTestingFixture fixture) : IClassFixt
         Assert.KeysAreEqual(createdKey, fromDeletedStore);
     }
 
-    [Fact(Skip = "Cyclical tests randomly failing on Github, issue #145")]
+    //[Fact(Skip = "Cyclical tests randomly failing on Github, issue #145")]
+    [Fact]
     public async Task GetAllKeyVersionsWillCycle()
     {
         var client = await fixture.GetClientAsync();
@@ -160,7 +161,8 @@ public sealed class KeysControllerTests(KeysTestingFixture fixture) : IClassFixt
         Assert.Equal(executionCount, matchingKeys.Count);
     }
 
-    [Fact(Skip = "Cyclical tests randomly failing on Github, issue #145")]
+    //[Fact(Skip = "Cyclical tests randomly failing on Github, issue #145")]
+    [Fact]
     public async Task GetOneHundredKeyVersionsCyclesThroughLink()
     {
         var client = await fixture.GetClientAsync();

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Secrets/DeletedSecretsControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Secrets/DeletedSecretsControllerTests.cs
@@ -27,7 +27,8 @@ namespace AzureKeyVaultEmulator.IntegrationTests.Secrets
             Assert.Equal(secret.Name, fromDeletedSource.Value.Name);
         }
 
-        [Fact(Skip = "Cyclical tests randomly failing on Github, issue #145")]
+        //[Fact(Skip = "Cyclical tests randomly failing on Github, issue #145")]
+        [Fact]
         public async Task GetDeletedSecretsPagesForCorrectCountTest()
         {
             var client = await fixture.GetClientAsync();

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Secrets/DeletedSecretsControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Secrets/DeletedSecretsControllerTests.cs
@@ -35,7 +35,7 @@ namespace AzureKeyVaultEmulator.IntegrationTests.Secrets
             var multiSecretName = fixture.FreshlyGeneratedGuid;
 
             var executionCount = await RequestSetup
-                .CreateMultiple(26, 51, i => client.SetSecretAsync(multiSecretName, $"{i}value"));
+                .CreateMultiple(26, 30, i => client.SetSecretAsync(multiSecretName, $"{i}value"));
 
             var deletedOperation = await client.StartDeleteSecretAsync(multiSecretName);
 

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Secrets/SecretsControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Secrets/SecretsControllerTests.cs
@@ -113,7 +113,8 @@ namespace AzureKeyVaultEmulator.IntegrationTests.Secrets
             Assert.Equal(executionCount, versions.Count);
         }
 
-        [Fact(Skip = "Cyclical tests randomly failing on Github, issue #145")]
+        //[Fact(Skip = "Cyclical tests randomly failing on Github, issue #145")]
+        [Fact]
         public async Task GetSecretsPagesAllSecretsCreatedTest()
         {
             var client = await fixture.GetClientAsync();

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Secrets/SecretsControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Secrets/SecretsControllerTests.cs
@@ -98,7 +98,7 @@ namespace AzureKeyVaultEmulator.IntegrationTests.Secrets
             var secretName = fixture.FreshlyGeneratedGuid;
 
             var executionCount = await RequestSetup
-                .CreateMultiple(26, 51, i => client.SetSecretAsync(secretName, $"{i}value"));
+                .CreateMultiple(26, 30, i => client.SetSecretAsync(secretName, $"{i}value"));
 
             var properties = client.GetPropertiesOfSecretVersionsAsync(secretName);
 
@@ -121,7 +121,7 @@ namespace AzureKeyVaultEmulator.IntegrationTests.Secrets
             var secretName = fixture.FreshlyGeneratedGuid;
 
             var executionCount = await RequestSetup
-                .CreateMultiple(26, 51, i => client.SetSecretAsync(secretName, $"{i}value"));
+                .CreateMultiple(26, 30, i => client.SetSecretAsync(secretName, $"{i}value"));
 
             var testSecrets = new List<SecretProperties?>();
 

--- a/test/AzureKeyVaultEmulator.IntegrationTests/SetupHelper/Fixtures/KeyVaultClientTestingFixture.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/SetupHelper/Fixtures/KeyVaultClientTestingFixture.cs
@@ -130,7 +130,6 @@ public abstract class KeyVaultClientTestingFixture<TClient> : IAsyncLifetime
         if (_app is not null)
             await _app.DisposeAsync().ConfigureAwait(false);
 
-        if (_testingClient is not null)
-            _testingClient.Dispose();
+        _testingClient?.Dispose();
     }
 }

--- a/test/AzureKeyVaultEmulator.IntegrationTests/SetupHelper/RequestSetup.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/SetupHelper/RequestSetup.cs
@@ -29,8 +29,8 @@ namespace AzureKeyVaultEmulator.IntegrationTests.SetupHelper
         }
 
         public static async Task<int> CreateMultiple<T>(
-    int lower, int upper,
-    Func<int, Task<T>> execution)
+            int lower, int upper,
+            Func<int, Task<T>> execution)
         {
             var executionCount = Random.Shared.Next(lower, upper);
 

--- a/test/AzureKeyVaultEmulator.Wiremock.IntegrationTests/WiremockTests.cs
+++ b/test/AzureKeyVaultEmulator.Wiremock.IntegrationTests/WiremockTests.cs
@@ -5,12 +5,16 @@ namespace AzureKeyVaultEmulator.Wiremock.IntegrationTests;
 
 public class WiremockTests(WiremockFixture fixture) : IClassFixture<WiremockFixture>
 {
+    private static TimeSpan _timeout = TimeSpan.FromSeconds(5);
+
     [Fact]
     public async Task WireMockEndpointReturnsCorrectly()
     {
+        var tokenSource = new CancellationTokenSource(_timeout);
+
         var httpClient = await fixture.GetHttpClient(AspireConstants.DebugHelper);
 
-        var response = await httpClient.GetAsync(WiremockConstants.EndpointName);
+        var response = await httpClient.GetAsync(WiremockConstants.EndpointName, tokenSource.Token);
         var content = await response.Content.ReadAsStringAsync();
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -20,9 +24,11 @@ public class WiremockTests(WiremockFixture fixture) : IClassFixture<WiremockFixt
     [Fact]
     public async Task CertificateCreationEndpointEstablishesSSLCorrectly()
     {
+        var tokenSource = new CancellationTokenSource(_timeout);
+
         var httpClient = await fixture.GetHttpClient(AspireConstants.DebugHelper);
 
-        var response = await httpClient.GetAsync("/");
+        var response = await httpClient.GetAsync("/", tokenSource.Token);
 
         var content = await response.Content.ReadAsStringAsync();
 


### PR DESCRIPTION
## Describe your changes

GH Actions were seemingly timing out cyclical tests which validated the behaviour of `nextLink=${JWE}` functionality. However since skipping all of these tests previously, more have been added and are functioning as expected.

All tests have been reenabled, along with reducing the total cycles in each test to between 26 and 30, where `nextLink` is generated for each batch of 25.

## Issue ticket number and link

* Fixes: #145 

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have ran the test suite locally to ensure no breaking changes have been added.
- [x] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [x] I have added new tests, if applicable.