### PR TITLE
Secrets will now respect overridden values

### DIFF
--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/Constants/KeyVaultEmulatorContainerConstants.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/Constants/KeyVaultEmulatorContainerConstants.cs
@@ -8,7 +8,7 @@ internal partial class KeyVaultEmulatorContainerConstants
     public const string Image = "jamesgoulddev/azure-keyvault-emulator";
     public const int Port = 4997;
 
-    public const string Tag = "2.6.2";
+    public const string Tag = "2.6.3";
     public static string ArmTag => $"{Tag}-arm";
 
 }

--- a/src/AzureKeyVaultEmulator.Shared/Models/Certificates/CertificateAttributes.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Certificates/CertificateAttributes.cs
@@ -2,7 +2,7 @@
 
 namespace AzureKeyVaultEmulator.Shared.Models.Certificates;
 
-public sealed class CertificateAttributesModel : AttributeBase
+public sealed class CertificateAttributes : AttributeBase
 {
     [JsonPropertyName("version")]
     public string Version { get; set; } = string.Empty;

--- a/src/AzureKeyVaultEmulator.Shared/Models/Certificates/CertificateBundle.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Certificates/CertificateBundle.cs
@@ -6,7 +6,8 @@ using AzureKeyVaultEmulator.Shared.Persistence.Interfaces;
 
 namespace AzureKeyVaultEmulator.Shared.Models.Certificates;
 
-public sealed class CertificateBundle : CertificateProperties, INamedItem
+public sealed class CertificateBundle
+    : CertificateProperties, INamedItem, IAttributedModel<CertificateAttributes>
 {
     [Key]
     [JsonIgnore]

--- a/src/AzureKeyVaultEmulator.Shared/Models/Certificates/CertificatePolicy.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Certificates/CertificatePolicy.cs
@@ -36,7 +36,7 @@ public sealed class CertificatePolicy : INamedItem
     public IssuerBundle Issuer { get; set; } = new();
 
     [JsonPropertyName("attributes")]
-    public CertificateAttributesModel CertificateAttributes { get; set; } = new();
+    public CertificateAttributes CertificateAttributes { get; set; } = new();
 
     [JsonPropertyName("x509_props")]
     public X509CertificateProperties? CertificateProperties { get; set; } = new();

--- a/src/AzureKeyVaultEmulator.Shared/Models/Certificates/CertificateProperties.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Certificates/CertificateProperties.cs
@@ -25,12 +25,12 @@ public class CertificateProperties : TaggedModel
     public required string X509Thumbprint { get; set; }
 
     [JsonPropertyName("status")]
-    public static string OperationStatus = OperationConstants.Completed; // del
+    public static string OperationStatus => OperationConstants.Completed; // del
 
     // Recovery not currently supported. Raise an issue if it's required please.
     [JsonPropertyName("recoveryLevelDays")]
     public int RecoveryLevelDays => 0;
 
     [JsonPropertyName("attributes")]
-    public CertificateAttributesModel Attributes { get; set; } = new();
+    public CertificateAttributes Attributes { get; set; } = new();
 }

--- a/src/AzureKeyVaultEmulator.Shared/Models/Certificates/CertificateVersionItem.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Certificates/CertificateVersionItem.cs
@@ -8,7 +8,7 @@ public sealed class CertificateVersionItem : TaggedModel
     public string Id { get; set; } = string.Empty;
 
     [JsonPropertyName("attributes")]
-    public CertificateAttributesModel Attributes { get; set; } = new();
+    public CertificateAttributes Attributes { get; set; } = new();
 
     [JsonPropertyName("x5t")]
     public string Thumbprint { get; set; } = string.Empty;

--- a/src/AzureKeyVaultEmulator.Shared/Models/Certificates/IssuerBundle.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Certificates/IssuerBundle.cs
@@ -9,7 +9,7 @@ using AzureKeyVaultEmulator.Shared.Utilities;
 namespace AzureKeyVaultEmulator.Shared.Models.Certificates;
 
 // https://learn.microsoft.com/en-us/rest/api/keyvault/certificates/get-certificate-issuer/get-certificate-issuer?view=rest-keyvault-certificates-7.4&tabs=HTTP#examples
-public sealed class IssuerBundle : INamedItem
+public sealed class IssuerBundle : INamedItem, IAttributedModel<IssuerAttributes>
 {
     [Key]
     [JsonIgnore]

--- a/src/AzureKeyVaultEmulator.Shared/Models/Certificates/Requests/CreateCertificateRequest.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Certificates/Requests/CreateCertificateRequest.cs
@@ -5,7 +5,7 @@ namespace AzureKeyVaultEmulator.Shared.Models.Certificates.Requests;
 public sealed class CreateCertificateRequest
 {
     [JsonPropertyName("attributes")]
-    public CertificateAttributesModel Attributes { get; set; } = new();
+    public CertificateAttributes Attributes { get; set; } = new();
 
     [JsonPropertyName("policy")]
     public CertificatePolicy CertificatePolicy { get; set; } = new();

--- a/src/AzureKeyVaultEmulator.Shared/Models/Certificates/Requests/ImportCertificateRequest.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Certificates/Requests/ImportCertificateRequest.cs
@@ -5,7 +5,7 @@ namespace AzureKeyVaultEmulator.Shared.Models.Certificates.Requests;
 public sealed class ImportCertificateRequest : ValueModel<string>
 {
     [JsonPropertyName("attributes")]
-    public CertificateAttributesModel Attributes { get; set; } = new();
+    public CertificateAttributes Attributes { get; set; } = new();
 
     [JsonPropertyName("policy")]
     public CertificatePolicy Policy { get; set; } = new();

--- a/src/AzureKeyVaultEmulator.Shared/Models/Certificates/Requests/MergeCertificatesRequest.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Certificates/Requests/MergeCertificatesRequest.cs
@@ -8,5 +8,5 @@ public sealed class MergeCertificatesRequest : TaggedModel
     public IEnumerable<string> Certificates { get; set; } = [];
 
     [JsonPropertyName("attributes")]
-    public CertificateAttributesModel Attributes { get; set; } = new();
+    public CertificateAttributes Attributes { get; set; } = new();
 }

--- a/src/AzureKeyVaultEmulator.Shared/Models/Certificates/Requests/UpdateCertificateRequest.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Certificates/Requests/UpdateCertificateRequest.cs
@@ -5,7 +5,7 @@ namespace AzureKeyVaultEmulator.Shared.Models.Certificates.Requests;
 public sealed class UpdateCertificateRequest : TaggedModel
 {
     [JsonPropertyName("attributes")]
-    public CertificateAttributesModel? Attributes { get; set; }
+    public CertificateAttributes? Attributes { get; set; }
 
     [JsonPropertyName("policy")]
     public CertificatePolicy? Policy { get; set; }

--- a/src/AzureKeyVaultEmulator.Shared/Models/IAttributedModel.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/IAttributedModel.cs
@@ -1,0 +1,6 @@
+﻿namespace AzureKeyVaultEmulator.Shared.Models;
+
+public interface IAttributedModel<TAttributes> where TAttributes : AttributeBase
+{
+    TAttributes Attributes { get; set; } 
+}

--- a/src/AzureKeyVaultEmulator.Shared/Models/Keys/CreateKey.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Keys/CreateKey.cs
@@ -3,14 +3,14 @@ using System.Text.Json.Serialization;
 
 namespace AzureKeyVaultEmulator.Shared.Models.Keys
 {
-    public class CreateKeyModel : ICreateItem
+    public class CreateKey : ICreateItem
     {
         [JsonPropertyName("kty")]
         [Required]
         public string KeyType { get; set; } = string.Empty;
 
         [JsonPropertyName("attributes")]
-        public KeyAttributesModel KeyAttributes { get; set; } = new();
+        public KeyAttributes KeyAttributes { get; set; } = new();
 
         [JsonPropertyName("release_policy")]
         public KeyReleasePolicy? keyReleasePolicy { get; set; }

--- a/src/AzureKeyVaultEmulator.Shared/Models/Keys/DeletedKeyBundle.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Keys/DeletedKeyBundle.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text.Json.Serialization;
-using Microsoft.IdentityModel.Tokens;
 
 namespace AzureKeyVaultEmulator.Shared.Models.Keys;
 

--- a/src/AzureKeyVaultEmulator.Shared/Models/Keys/DeletedKeyBundle.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Keys/DeletedKeyBundle.cs
@@ -3,8 +3,8 @@ using Microsoft.IdentityModel.Tokens;
 
 namespace AzureKeyVaultEmulator.Shared.Models.Keys;
 
-public sealed class DeletedKeyBundle : DeletedBundle<KeyAttributesModel>
+public sealed class DeletedKeyBundle : DeletedBundle<KeyAttributes>
 {
     [JsonPropertyName("key")]
-    public required JsonWebKey Key { get; set; }
+    public required Microsoft.IdentityModel.Tokens.JsonWebKey Key { get; set; }
 }

--- a/src/AzureKeyVaultEmulator.Shared/Models/Keys/InternalJsonWebKey.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Keys/InternalJsonWebKey.cs
@@ -11,7 +11,7 @@ using Microsoft.IdentityModel.Tokens;
 
 namespace AzureKeyVaultEmulator.Shared.Models.Keys
 {
-    public class JsonWebKey : IPersistedItem
+    public class InternalJsonWebKey : IPersistedItem
     {
         [Key]
         [JsonIgnore]
@@ -98,9 +98,9 @@ namespace AzureKeyVaultEmulator.Shared.Models.Keys
         [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
         public RSAParameters RSAParameters => RsaParametersSerializer.Deserialize(RSAParametersBlob);
 
-        public JsonWebKey() : this(RSA.Create()) { }
+        public InternalJsonWebKey() : this(RSA.Create()) { }
 
-        public JsonWebKey(RSA rsaKey)
+        public InternalJsonWebKey(RSA rsaKey)
         {
             RSAKey = rsaKey;
 
@@ -117,7 +117,7 @@ namespace AzureKeyVaultEmulator.Shared.Models.Keys
             Qi = EncodingUtils.Base64UrlEncode(RSAParameters.InverseQ ?? []);
         }
 
-        public JsonWebKey(Microsoft.IdentityModel.Tokens.JsonWebKey key, string name, string version, HttpContext? reqContext)
+        public InternalJsonWebKey(JsonWebKey key, string name, string version, HttpContext? reqContext)
         {
             var parameters = new RSAParameters
             {

--- a/src/AzureKeyVaultEmulator.Shared/Models/Keys/JsonWebKey.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Keys/JsonWebKey.cs
@@ -11,7 +11,7 @@ using Microsoft.IdentityModel.Tokens;
 
 namespace AzureKeyVaultEmulator.Shared.Models.Keys
 {
-    public class JsonWebKeyModel : IPersistedItem
+    public class JsonWebKey : IPersistedItem
     {
         [Key]
         [JsonIgnore]
@@ -98,9 +98,9 @@ namespace AzureKeyVaultEmulator.Shared.Models.Keys
         [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
         public RSAParameters RSAParameters => RsaParametersSerializer.Deserialize(RSAParametersBlob);
 
-        public JsonWebKeyModel() : this(RSA.Create()) { }
+        public JsonWebKey() : this(RSA.Create()) { }
 
-        public JsonWebKeyModel(RSA rsaKey)
+        public JsonWebKey(RSA rsaKey)
         {
             RSAKey = rsaKey;
 
@@ -117,7 +117,7 @@ namespace AzureKeyVaultEmulator.Shared.Models.Keys
             Qi = EncodingUtils.Base64UrlEncode(RSAParameters.InverseQ ?? []);
         }
 
-        public JsonWebKeyModel(JsonWebKey key, string name, string version, HttpContext? reqContext)
+        public JsonWebKey(Microsoft.IdentityModel.Tokens.JsonWebKey key, string name, string version, HttpContext? reqContext)
         {
             var parameters = new RSAParameters
             {

--- a/src/AzureKeyVaultEmulator.Shared/Models/Keys/KeyAttributes.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Keys/KeyAttributes.cs
@@ -1,6 +1,6 @@
 namespace AzureKeyVaultEmulator.Shared.Models.Keys;
 
-public class KeyAttributesModel : AttributeBase
+public class KeyAttributes : AttributeBase
 {
 
 }

--- a/src/AzureKeyVaultEmulator.Shared/Models/Keys/KeyBundle.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Keys/KeyBundle.cs
@@ -17,7 +17,7 @@ namespace AzureKeyVaultEmulator.Shared.Models.Keys
         public string PersistedVersion { get; set; } = string.Empty;
 
         [JsonPropertyName("key")]
-        public required JsonWebKey Key { get; set; }
+        public required InternalJsonWebKey Key { get; set; }
 
         [JsonPropertyName("attributes")]
         public KeyAttributes Attributes { get; set; } = new();

--- a/src/AzureKeyVaultEmulator.Shared/Models/Keys/KeyBundle.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Keys/KeyBundle.cs
@@ -5,7 +5,7 @@ using AzureKeyVaultEmulator.Shared.Persistence.Interfaces;
 
 namespace AzureKeyVaultEmulator.Shared.Models.Keys
 {
-    public class KeyBundle : TaggedModel, INamedItem
+    public class KeyBundle : TaggedModel, INamedItem, IAttributedModel<KeyAttributes>
     {
         [Key]
         [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
@@ -17,10 +17,10 @@ namespace AzureKeyVaultEmulator.Shared.Models.Keys
         public string PersistedVersion { get; set; } = string.Empty;
 
         [JsonPropertyName("key")]
-        public required JsonWebKeyModel Key { get; set; }
+        public required JsonWebKey Key { get; set; }
 
         [JsonPropertyName("attributes")]
-        public KeyAttributesModel Attributes { get; set; } = new();
+        public KeyAttributes Attributes { get; set; } = new();
 
         [JsonIgnore]
         public bool Deleted { get; set; } = false;

--- a/src/AzureKeyVaultEmulator.Shared/Models/Keys/KeyItemBundle.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Keys/KeyItemBundle.cs
@@ -6,7 +6,7 @@ namespace AzureKeyVaultEmulator.Shared.Models.Keys;
 public sealed class KeyItemBundle : TaggedModel
 {
     [JsonPropertyName("attributes")]
-    public KeyAttributesModel KeyAttributes { get; set; } = new();
+    public KeyAttributes KeyAttributes { get; set; } = new();
 
     [JsonPropertyName("kid")]
     public required string KeyId { get; set; }

--- a/src/AzureKeyVaultEmulator.Shared/Models/Keys/Requests/ImportKeyRequest.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Keys/Requests/ImportKeyRequest.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text.Json.Serialization;
-using Microsoft.IdentityModel.Tokens;
 
 namespace AzureKeyVaultEmulator.Shared.Models.Keys.RequestModels;
 

--- a/src/AzureKeyVaultEmulator.Shared/Models/Keys/Requests/ImportKeyRequest.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Keys/Requests/ImportKeyRequest.cs
@@ -6,13 +6,13 @@ namespace AzureKeyVaultEmulator.Shared.Models.Keys.RequestModels;
 public sealed class ImportKeyRequest
 {
     [JsonPropertyName("key")]
-    public required JsonWebKey Key { get; set; }
+    public required Microsoft.IdentityModel.Tokens.JsonWebKey Key { get; set; }
 
     [JsonPropertyName("hsm")]
     public bool? HSM { get; set; }
 
     [JsonPropertyName("attributes")]
-    public KeyAttributesModel KeyAttributes { get; set; } = new();
+    public KeyAttributes KeyAttributes { get; set; } = new();
 
     [JsonPropertyName("release_policy")]
     public object? ReleasePolicy { get; set; }

--- a/src/AzureKeyVaultEmulator.Shared/Models/Keys/Requests/UpdateKeyRequest.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Keys/Requests/UpdateKeyRequest.cs
@@ -5,7 +5,7 @@ namespace AzureKeyVaultEmulator.Shared.Models.Keys.RequestModels;
 public sealed class UpdateKeyRequest
 {
     [JsonPropertyName("attributes")]
-    public KeyAttributesModel Attributes { get; set; } = new();
+    public KeyAttributes Attributes { get; set; } = new();
 
     [JsonPropertyName("tags")]
     public Dictionary<string, string> Tags { get; set; } = [];

--- a/src/AzureKeyVaultEmulator.Shared/Models/Secrets/DeletedSecretBundle.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Secrets/DeletedSecretBundle.cs
@@ -2,7 +2,7 @@
 
 namespace AzureKeyVaultEmulator.Shared.Models.Secrets
 {
-    public class DeletedSecretBundle : DeletedBundle<SecretAttributesModel>
+    public class DeletedSecretBundle : DeletedBundle<SecretAttributes>
     {
 
         [JsonPropertyName("id")]

--- a/src/AzureKeyVaultEmulator.Shared/Models/Secrets/Requests/SetSecretRequest.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Secrets/Requests/SetSecretRequest.cs
@@ -13,7 +13,7 @@ namespace AzureKeyVaultEmulator.Shared.Models.Secrets.Requests
         public string ContentType { get; set; } = string.Empty;
 
         [JsonPropertyName("attributes")]
-        public SecretAttributesModel SecretAttributes { get; set; } = new();
+        public SecretAttributes SecretAttributes { get; set; } = new();
 
         [JsonPropertyName("tags")]
         public Dictionary<string, string> Tags { get; set; } = [];

--- a/src/AzureKeyVaultEmulator.Shared/Models/Secrets/Requests/UpdateSecretRequest.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Secrets/Requests/UpdateSecretRequest.cs
@@ -5,7 +5,7 @@ namespace AzureKeyVaultEmulator.Shared.Models.Secrets.Requests
     public class UpdateSecretRequest
     {
         [JsonPropertyName("attributes")]
-        public SecretAttributesModel? Attributes { get; set; }
+        public SecretAttributes? Attributes { get; set; }
 
         [JsonPropertyName("contentType")]
         public string ContentType { get; set; } = string.Empty;

--- a/src/AzureKeyVaultEmulator.Shared/Models/Secrets/SecretAttributes.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Secrets/SecretAttributes.cs
@@ -1,6 +1,6 @@
 namespace AzureKeyVaultEmulator.Shared.Models.Secrets;
 
-public class SecretAttributesModel : AttributeBase
+public class SecretAttributes : AttributeBase
 {
 
 }

--- a/src/AzureKeyVaultEmulator.Shared/Models/Secrets/SecretBundle.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Models/Secrets/SecretBundle.cs
@@ -5,7 +5,7 @@ using AzureKeyVaultEmulator.Shared.Persistence.Interfaces;
 
 namespace AzureKeyVaultEmulator.Shared.Models.Secrets;
 
-public sealed class SecretBundle : TaggedModel, INamedItem
+public sealed class SecretBundle : TaggedModel, INamedItem, IAttributedModel<SecretAttributes>
 {
     [Key]
     [JsonIgnore]
@@ -29,5 +29,5 @@ public sealed class SecretBundle : TaggedModel, INamedItem
     public string ContentType { get; set; } = string.Empty;
 
     [JsonPropertyName("attributes")]
-    public SecretAttributesModel Attributes { get; set; } = new();
+    public SecretAttributes Attributes { get; set; } = new();
 }

--- a/src/AzureKeyVaultEmulator.Shared/Utilities/DictionaryUtils.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Utilities/DictionaryUtils.cs
@@ -33,7 +33,7 @@ public static class DictionaryUtils
         string version = "",
         bool deleted = false)
     where TEntity : class, INamedItem, IDeletable, IAttributedModel<TAttributes>
-        where TAttributes : AttributeBase
+    where TAttributes : AttributeBase
     {
         ArgumentNullException.ThrowIfNull(set);
         ArgumentException.ThrowIfNullOrEmpty(name);

--- a/src/AzureKeyVaultEmulator/Certificates/Services/CertificateBackingService.cs
+++ b/src/AzureKeyVaultEmulator/Certificates/Services/CertificateBackingService.cs
@@ -19,7 +19,7 @@ public sealed class CertificateBackingService(
 {
     public async Task<IssuerBundle> GetIssuerAsync(string name)
     {
-        return await context.Issuers.SafeGetAsync(name);
+        return await context.Issuers.SafeGetAsync<IssuerBundle, IssuerAttributes>(name);
     }
 
     public async Task<(KeyBundle backingKey, SecretBundle backingSecret)> GetBackingComponentsAsync(
@@ -46,7 +46,7 @@ public sealed class CertificateBackingService(
     {
         ArgumentException.ThrowIfNullOrEmpty(issuerName);
 
-        var bundle = await context.Issuers.SafeGetAsync(issuerName);
+        var bundle = await context.Issuers.SafeGetAsync<IssuerBundle, IssuerAttributes>(issuerName);
 
         bundle.Deleted = true;
 
@@ -78,8 +78,8 @@ public sealed class CertificateBackingService(
         ArgumentException.ThrowIfNullOrEmpty(certName);
         ArgumentNullException.ThrowIfNull(bundle);
 
-        var cert = await context.Certificates.SafeGetAsync(certName);
-        var issuer = await context.Issuers.SafeGetAsync(bundle.IssuerName);
+        var cert = await context.Certificates.SafeGetAsync<CertificateBundle, CertificateAttributes>(certName);
+        var issuer = await context.Issuers.SafeGetAsync<IssuerBundle, IssuerAttributes>(bundle.IssuerName);
 
         if (cert.CertificatePolicy == null)
             throw new MissingItemException($"Certificate {certName} does not have an associated policy to update");
@@ -99,7 +99,7 @@ public sealed class CertificateBackingService(
         ArgumentException.ThrowIfNullOrEmpty(issuerName);
         ArgumentNullException.ThrowIfNull(bundle);
 
-        var fromStore = await context.Issuers.SafeGetAsync(issuerName);
+        var fromStore = await context.Issuers.SafeGetAsync<IssuerBundle, IssuerAttributes>(issuerName);
 
         fromStore.OrganisationDetails = bundle.OrganisationDetails;
         fromStore.Attributes = bundle.Attributes;
@@ -167,7 +167,7 @@ public sealed class CertificateBackingService(
         int keySize,
         string keyType)
     {
-        return await keyService.CreateKeyAsync(certName, new CreateKeyModel { KeySize = keySize, KeyType = keyType });
+        return await keyService.CreateKeyAsync(certName, new CreateKey { KeySize = keySize, KeyType = keyType });
     }
 
     private async Task<SecretBundle> CreateBackingSecretAsync(

--- a/src/AzureKeyVaultEmulator/Certificates/Services/CertificateService.cs
+++ b/src/AzureKeyVaultEmulator/Certificates/Services/CertificateService.cs
@@ -18,7 +18,7 @@ public sealed class CertificateService(
 {
     public async Task<CertificateOperation> CreateCertificateAsync(
         string name,
-        CertificateAttributesModel attributes,
+        CertificateAttributes attributes,
         CertificatePolicy? policy,
         Dictionary<string, string>? tags = null)
     {
@@ -220,7 +220,7 @@ public sealed class CertificateService(
         var (backingKey, backingSecret) = await backingService
             .GetBackingComponentsAsync(name, certificate, request.Password, request.Policy, contentType);
 
-        var attributes = new CertificateAttributesModel
+        var attributes = new CertificateAttributes
         {
             Version = version,
             NotBefore = certificate.NotBefore.ToUnixTimeSeconds(),
@@ -388,7 +388,7 @@ public sealed class CertificateService(
     private static CertificatePolicy UpdateNullablePolicy(
         CertificatePolicy? policy,
         string identifier,
-        CertificateAttributesModel attributes,
+        CertificateAttributes attributes,
         SecretBundle? secret = null,
         KeyBundle? key = null)
     {

--- a/src/AzureKeyVaultEmulator/Certificates/Services/CertificateService.cs
+++ b/src/AzureKeyVaultEmulator/Certificates/Services/CertificateService.cs
@@ -60,8 +60,6 @@ public sealed class CertificateService(
 
         context.Add(bundle);
 
-        //await context.Certificates.SafeAddAsync(name, version, bundle);
-
         await context.SaveChangesAsync();
 
         return new CertificateOperation(certIdentifier, name);
@@ -71,14 +69,14 @@ public sealed class CertificateService(
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
 
-        return await context.Certificates.SafeGetAsync(name, version);
+        return await context.Certificates.SafeGetAsync<CertificateBundle, CertificateAttributes>(name, version);
     }
 
     public async Task<CertificatePolicy> GetCertificatePolicyAsync(string name)
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
 
-        var cert = await context.Certificates.SafeGetAsync(name);
+        var cert = await context.Certificates.SafeGetAsync<CertificateBundle, CertificateAttributes>(name);
 
         return cert.CertificatePolicy
             ?? throw new InvalidOperationException($"Found certificate {cert.CertificateName} but the associated policy was null.");
@@ -88,7 +86,7 @@ public sealed class CertificateService(
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
 
-        var cert = await context.Certificates.SafeGetAsync(name);
+        var cert = await context.Certificates.SafeGetAsync<CertificateBundle, CertificateAttributes>(name);
 
         ArgumentNullException.ThrowIfNull(cert.CertificatePolicy);
 
@@ -105,7 +103,7 @@ public sealed class CertificateService(
         ArgumentException.ThrowIfNullOrEmpty(name);
         ArgumentNullException.ThrowIfNull(request);
 
-        var cert = await context.Certificates.SafeGetAsync(name, version: version ?? string.Empty);
+        var cert = await context.Certificates.SafeGetAsync<CertificateBundle, CertificateAttributes>(name, version: version ?? string.Empty);
 
         cert.CertificatePolicy = request.Policy ??= cert.CertificatePolicy;
         cert.Attributes = request.Attributes ?? cert.Attributes;
@@ -120,7 +118,7 @@ public sealed class CertificateService(
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
 
-        var cert = await context.Certificates.SafeGetAsync(name);
+        var cert = await context.Certificates.SafeGetAsync<CertificateBundle, CertificateAttributes>(name);
 
         return new CertificateOperation(cert.CertificateIdentifier, name);
     }
@@ -136,7 +134,7 @@ public sealed class CertificateService(
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
 
-        var cert = await context.Certificates.SafeGetAsync(name);
+        var cert = await context.Certificates.SafeGetAsync<CertificateBundle, CertificateAttributes>(name);
 
         return new ValueModel<string>
         {
@@ -258,7 +256,7 @@ public sealed class CertificateService(
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
 
-        var cert = await context.Certificates.SafeGetAsync(name.GetCacheId());
+        var cert = await context.Certificates.SafeGetAsync<CertificateBundle, CertificateAttributes>(name.GetCacheId());
 
         ArgumentNullException.ThrowIfNull(cert.FullCertificate);
 
@@ -279,7 +277,7 @@ public sealed class CertificateService(
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
 
-        var cert = await context.Certificates.SafeGetAsync(name);
+        var cert = await context.Certificates.SafeGetAsync<CertificateBundle, CertificateAttributes>(name);
 
         var matches = await context.Certificates.Where(x => x.PersistedName == name).ToListAsync();
 
@@ -297,7 +295,7 @@ public sealed class CertificateService(
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
 
-        var cert = await context.Certificates.SafeGetAsync(name, deleted: true);
+        var cert = await context.Certificates.SafeGetAsync<CertificateBundle, CertificateAttributes>(name, deleted: true);
 
         return new(cert.CertificateIdentifier, name.GetCacheId());
     }
@@ -327,7 +325,7 @@ public sealed class CertificateService(
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
 
-        var cert = await context.Certificates.SafeGetAsync(name, deleted: true);
+        var cert = await context.Certificates.SafeGetAsync<CertificateBundle, CertificateAttributes>(name, deleted: true);
 
         return new CertificateOperation(cert.RecoveryId, name);
     }
@@ -336,7 +334,7 @@ public sealed class CertificateService(
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
 
-        var bundle = await context.Certificates.SafeGetAsync(name, deleted: true);
+        var bundle = await context.Certificates.SafeGetAsync<CertificateBundle, CertificateAttributes>(name, deleted: true);
 
         var fullCertificate = bundle.FullCertificate;
 
@@ -353,7 +351,7 @@ public sealed class CertificateService(
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
 
-        var cert = await context.Certificates.SafeGetAsync(name);
+        var cert = await context.Certificates.SafeGetAsync<CertificateBundle, CertificateAttributes>(name);
 
         return new(cert.CertificateIdentifier, name);
     }

--- a/src/AzureKeyVaultEmulator/Certificates/Services/ICertificateService.cs
+++ b/src/AzureKeyVaultEmulator/Certificates/Services/ICertificateService.cs
@@ -6,7 +6,7 @@ namespace AzureKeyVaultEmulator.Certificates.Services;
 
 public interface ICertificateService
 {
-    Task<CertificateOperation> CreateCertificateAsync(string name, CertificateAttributesModel attributes, CertificatePolicy? policy, Dictionary<string, string>? tags = null);
+    Task<CertificateOperation> CreateCertificateAsync(string name, CertificateAttributes attributes, CertificatePolicy? policy, Dictionary<string, string>? tags = null);
     Task<CertificateBundle> GetCertificateAsync(string name, string version = "");
     Task<ListResult<CertificateVersionItem>> GetCertificatesAsync(int maxResults = 25, int skipToken = 25);
     Task<ListResult<CertificateVersionItem>> GetCertificateVersionsAsync(string name, int maxResults = 25, int skipCount = 25);

--- a/src/AzureKeyVaultEmulator/Keys/Controllers/KeysController.cs
+++ b/src/AzureKeyVaultEmulator/Keys/Controllers/KeysController.cs
@@ -15,7 +15,7 @@ namespace AzureKeyVaultEmulator.Keys.Controllers
         public async Task<IActionResult> CreateKey(
             [FromRoute] string name,
             [ApiVersion] string apiVersion,
-            [FromBody] CreateKeyModel requestBody)
+            [FromBody] CreateKey requestBody)
         {
             var createdKey = await keyService.CreateKeyAsync(name, requestBody);
 

--- a/src/AzureKeyVaultEmulator/Keys/Services/IKeyService.cs
+++ b/src/AzureKeyVaultEmulator/Keys/Services/IKeyService.cs
@@ -6,8 +6,8 @@ namespace AzureKeyVaultEmulator.Keys.Services
     {
         Task<KeyBundle> GetKeyAsync(string name);
         Task<KeyBundle> GetKeyAsync(string name, string version);
-        Task<KeyBundle> CreateKeyAsync(string name, CreateKeyModel key);
-        Task<KeyAttributesModel?> UpdateKeyAsync(string name, string version, KeyAttributesModel attributes, Dictionary<string, string> tags);
+        Task<KeyBundle> CreateKeyAsync(string name, CreateKey key);
+        Task<KeyAttributes?> UpdateKeyAsync(string name, string version, KeyAttributes attributes, Dictionary<string, string> tags);
         Task<KeyBundle?> RotateKey(string name, string version);
 
         ValueModel<string> GetRandomBytes(int count);
@@ -25,7 +25,7 @@ namespace AzureKeyVaultEmulator.Keys.Services
         ListResult<KeyItemBundle> GetKeyVersions(string name, int maxResults = 25, int skipCount = 25);
 
         Task<ValueModel<string>> ReleaseKeyAsync(string name, string version);
-        Task<KeyBundle> ImportKeyAsync(string name, JsonWebKey key, KeyAttributesModel attributes, Dictionary<string, string> tags);
+        Task<KeyBundle> ImportKeyAsync(string name, JsonWebKey key, KeyAttributes attributes, Dictionary<string, string> tags);
         Task<KeyOperationResult> SignWithKeyAsync(string name, string version, string algo, string value);
         Task<ValueModel<bool>> VerifyDigestAsync(string name, string version, string digest, string signature);
 

--- a/src/AzureKeyVaultEmulator/Keys/Services/KeyService.cs
+++ b/src/AzureKeyVaultEmulator/Keys/Services/KeyService.cs
@@ -28,7 +28,7 @@ namespace AzureKeyVaultEmulator.Keys.Services
             return await context.Keys.SafeGetAsync(name, version);
         }
 
-        public async Task<KeyBundle> CreateKeyAsync(string name, CreateKeyModel key)
+        public async Task<KeyBundle> CreateKeyAsync(string name, CreateKey key)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
@@ -56,10 +56,10 @@ namespace AzureKeyVaultEmulator.Keys.Services
             return response;
         }
 
-        public async Task<KeyAttributesModel?> UpdateKeyAsync(
+        public async Task<KeyAttributes?> UpdateKeyAsync(
             string name,
             string version,
-            KeyAttributesModel attributes,
+            KeyAttributes attributes,
             Dictionary<string, string> tags)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(name);
@@ -257,15 +257,15 @@ namespace AzureKeyVaultEmulator.Keys.Services
 
         public async Task<KeyBundle> ImportKeyAsync(
             string name,
-            JsonWebKey key,
-            KeyAttributesModel attributes,
+            Microsoft.IdentityModel.Tokens.JsonWebKey key,
+            KeyAttributes attributes,
             Dictionary<string, string> tags)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
             var version = Guid.NewGuid().ToString();
 
-            var jsonWebKey = new JsonWebKeyModel(key, name, version, httpContextAccessor.HttpContext);
+            var jsonWebKey = new Shared.Models.Keys.JsonWebKey(key, name, version, httpContextAccessor.HttpContext);
 
             var response = new KeyBundle
             {
@@ -370,7 +370,7 @@ namespace AzureKeyVaultEmulator.Keys.Services
                 Attributes = parentKey.Attributes,
                 RecoveryId = $"{AuthConstants.EmulatorUri}/deletedkeys/{name}",
                 Tags = parentKey.Tags,
-                Key = new JsonWebKey(JsonSerializer.Serialize(parentKey.Key)),
+                Key = new Microsoft.IdentityModel.Tokens.JsonWebKey(JsonSerializer.Serialize(parentKey.Key)),
             };
         }
 
@@ -437,11 +437,11 @@ namespace AzureKeyVaultEmulator.Keys.Services
             };
         }
 
-        private static JsonWebKeyModel GetJWKSFromModel(int keySize, string keyType)
+        private static Shared.Models.Keys.JsonWebKey GetJWKSFromModel(int keySize, string keyType)
         {
             return keyType.ToUpper() switch
             {
-                SupportedKeyTypes.RSA => new JsonWebKeyModel(RsaKeyFactory.CreateRsaKey(keySize)),
+                SupportedKeyTypes.RSA => new Shared.Models.Keys.JsonWebKey(RsaKeyFactory.CreateRsaKey(keySize)),
                 SupportedKeyTypes.EC => throw new NotImplementedException("Elliptic Curve keys are not currently supported."),
                 _ => throw new NotImplementedException($"Key type {keyType} is not supported")
             };

--- a/src/AzureKeyVaultEmulator/Secrets/Services/SecretService.cs
+++ b/src/AzureKeyVaultEmulator/Secrets/Services/SecretService.cs
@@ -12,7 +12,7 @@ namespace AzureKeyVaultEmulator.Secrets.Services
     {
         public async Task<SecretBundle> GetSecretAsync(string name, string version = "")
         {
-            return await context.Secrets.SafeGetAsync(name, version);
+            return await context.Secrets.SafeGetAsync<SecretBundle, SecretAttributes>(name, version);
         }
 
         public async Task<SecretBundle> SetSecretAsync(string name, SetSecretRequest secret)
@@ -45,7 +45,7 @@ namespace AzureKeyVaultEmulator.Secrets.Services
             ArgumentException.ThrowIfNullOrWhiteSpace(name);
             ArgumentException.ThrowIfNullOrWhiteSpace(version);
 
-            var secret = await context.Secrets.SafeGetAsync(name, version);
+            var secret = await context.Secrets.SafeGetAsync<SecretBundle, SecretAttributes>(name, version);
 
             if (!string.IsNullOrEmpty(request.ContentType))
                 secret.ContentType = request.ContentType;
@@ -66,7 +66,7 @@ namespace AzureKeyVaultEmulator.Secrets.Services
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
-            var secret = await context.Secrets.SafeGetAsync(name, version);
+            var secret = await context.Secrets.SafeGetAsync<SecretBundle, SecretAttributes>(name, version);
 
             var deleted = new DeletedSecretBundle
             {
@@ -88,7 +88,7 @@ namespace AzureKeyVaultEmulator.Secrets.Services
         {
             ArgumentException.ThrowIfNullOrEmpty(name);
 
-            var secret = await context.Secrets.SafeGetAsync(name);
+            var secret = await context.Secrets.SafeGetAsync<SecretBundle, SecretAttributes>(name);
 
             return new ValueModel<string>
             {
@@ -100,7 +100,7 @@ namespace AzureKeyVaultEmulator.Secrets.Services
         {
             ArgumentException.ThrowIfNullOrEmpty(name);
             
-            var secret = await context.Secrets.SafeGetAsync(name, deleted: true);
+            var secret = await context.Secrets.SafeGetAsync<SecretBundle, SecretAttributes>(name, deleted: true);
 
             return secret;
         }
@@ -179,7 +179,7 @@ namespace AzureKeyVaultEmulator.Secrets.Services
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(name);
             
-            var secret = await context.Secrets.SafeGetAsync(name, deleted: true);
+            var secret = await context.Secrets.SafeGetAsync<SecretBundle, SecretAttributes>(name, deleted: true);
 
             secret.Deleted = false;
 

--- a/src/TestContainers/dotnet/Constants/AzureKeyVaultEmulatorContainerConstants.cs
+++ b/src/TestContainers/dotnet/Constants/AzureKeyVaultEmulatorContainerConstants.cs
@@ -8,7 +8,7 @@ namespace AzureKeyVaultEmulator.TestContainers.Constants
         public const string Image = "jamesgoulddev/azure-keyvault-emulator";
         public const int Port = 4997;
 
-        public const string Tag = "2.6.2";
+        public const string Tag = "2.6.3";
         public static string ArmTag => $"{Tag}-arm";
     }
 

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Secrets/DeletedSecretsControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Secrets/DeletedSecretsControllerTests.cs
@@ -130,6 +130,8 @@ namespace AzureKeyVaultEmulator.IntegrationTests.Secrets
 
             var deleteOperation = await client.StartDeleteSecretAsync(secretName);
 
+            await deleteOperation.WaitForCompletionAsync();
+
             var fromStoreResponse = await client.GetDeletedSecretAsync(secretName);
 
             var fromStore = fromStoreResponse.Value;

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Secrets/DeletedSecretsControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Secrets/DeletedSecretsControllerTests.cs
@@ -104,7 +104,38 @@ namespace AzureKeyVaultEmulator.IntegrationTests.Secrets
             Assert.Equal(secretName, afterRecovery.Value.Name);
 
             await Assert.RequestFailsAsync(() => client.GetDeletedSecretAsync(secretName));
+        }
 
+        [Fact]
+        public async Task CreatedAndOverridenDeletedSecretWillReturnUpdatedValue()
+        {
+            var client = await fixture.GetClientAsync();
+
+            var secretName = fixture.FreshlyGeneratedGuid;
+            var initialValue = fixture.FreshlyGeneratedGuid;
+            var overrideValue = fixture.FreshlyGeneratedGuid;
+
+            var initialSecret = await fixture.CreateSecretAsync(secretName, initialValue);
+
+            Assert.Equal(secretName, initialSecret.Name);
+            Assert.Equal(initialValue, initialSecret.Value);
+
+            // Ensure underpinning unix time is 100% different
+            await Task.Delay(500);
+
+            var overrideSecret = await fixture.CreateSecretAsync(secretName, overrideValue);
+
+            Assert.Equal(secretName, overrideSecret.Name);
+            Assert.Equal(overrideValue, overrideSecret.Value);
+
+            var deleteOperation = await client.StartDeleteSecretAsync(secretName);
+
+            var fromStoreResponse = await client.GetDeletedSecretAsync(secretName);
+
+            var fromStore = fromStoreResponse.Value;
+
+            Assert.Equal(secretName, fromStore.Name);
+            Assert.Equal(overrideValue, fromStore.Value);
         }
     }
 }

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Secrets/SecretsControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Secrets/SecretsControllerTests.cs
@@ -275,5 +275,35 @@ namespace AzureKeyVaultEmulator.IntegrationTests.Secrets
             await Assert.RequestFailsAsync(() => client.GetDeletedSecretAsync(secretName));
             await Assert.RequestFailsAsync(() => client.GetSecretAsync(secretName));
         }
+
+        [Fact]
+        public async Task CreatedAndOverridenSecretWillReturnUpdatedValue()
+        {
+            var client = await fixture.GetClientAsync();
+
+            var secretName = fixture.FreshlyGeneratedGuid;
+            var initialValue = fixture.FreshlyGeneratedGuid;
+            var overrideValue = fixture.FreshlyGeneratedGuid;
+
+            var initialSecret = await fixture.CreateSecretAsync(secretName, initialValue);
+
+            Assert.Equal(secretName, initialSecret.Name);
+            Assert.Equal(initialValue, initialSecret.Value);
+
+            // Ensure underpinning unix time is 100% different
+            await Task.Delay(500);
+
+            var overrideSecret = await fixture.CreateSecretAsync(secretName, overrideValue);
+
+            Assert.Equal(secretName, overrideSecret.Name);
+            Assert.Equal(overrideValue, overrideSecret.Value);
+
+            var fromStoreResponse = await client.GetSecretAsync(secretName);
+
+            var fromStore = fromStoreResponse.Value;
+
+            Assert.Equal(secretName, fromStore.Name);
+            Assert.Equal(overrideValue, fromStore.Value);
+        }
     }
 }


### PR DESCRIPTION
## Describe your changes

When duplicate secret names are `Set` into the vault, previously a new version of `SecretName` would be created and the value returned would be whatever entity framework decided was best.

This PR introduces a new `IAttributedModel<TAttributes> where TAttributes : AttributeBase` constraint to `DbSet.SafeGet` to enforce the lastest `TAttributes.Updated` is returned back where appropriate.

New tests have been added to ensure the behaviour is consistent across various collections that require it.

## Issue ticket number and link

* Fixes: #348 

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have ran the test suite locally to ensure no breaking changes have been added.
- [x] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [x] I have added new tests, if applicable.