### PR TITLE
Remove Microsoft.AspNetCore dependency

### DIFF
--- a/src/AzureKeyVaultEmulator.Client/AzureKeyVaultEmulator.Client.csproj
+++ b/src/AzureKeyVaultEmulator.Client/AzureKeyVaultEmulator.Client.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.8.0" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.8.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" />
   </ItemGroup>
 


### PR DESCRIPTION
## Describe your changes

Replaces `Microsoft.AspNetCore` dependency with `Microsoft.Extensions.Hosting.Abstractions`. This has 2 main benefits:
- Avoids pulling [Microsoft.AspNetCore.Server.Kestrel.Core](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.Kestrel.Core/2.3.0) which has a severe vulnerability.
- Reduces the number of transitive dependencies

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have ran the test suite locally to ensure no breaking changes have been added.
- [x] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [x] I have added new tests, if applicable.