### PR TITLE
Tests updated to dispose of testing container using IAsyncLifetime pattern as random port is always assigned

### DIFF
--- a/AzureKeyVaultEmulator.sln
+++ b/AzureKeyVaultEmulator.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.13.35828.75
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.11205.157 d18.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureKeyVaultEmulator", "src\AzureKeyVaultEmulator\AzureKeyVaultEmulator.csproj", "{ABAEE20D-4E4B-45CF-ABEA-A02263F63615}"
 EndProject
@@ -28,8 +28,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureKeyVaultEmulator.TestContainers", "src\TestContainers\dotnet\AzureKeyVaultEmulator.TestContainers.csproj", "{D5EA7180-0D91-414B-86A4-BB9885A26305}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureKeyVaultEmulator.TestContainers.Tests", "test\AzureKeyVaultEmulator.TestContainers.Tests\AzureKeyVaultEmulator.TestContainers.Tests.csproj", "{CDEB06F2-3EA5-4DED-8113-E732EFBC800B}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureKeyVaultEmulator.Wiremock.IntegrationTests", "test\AzureKeyVaultEmulator.Wiremock.IntegrationTests\AzureKeyVaultEmulator.Wiremock.IntegrationTests.csproj", "{FF15C174-6F00-4C77-AAE5-B98ACC68C17E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -73,10 +71,6 @@ Global
 		{CDEB06F2-3EA5-4DED-8113-E732EFBC800B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CDEB06F2-3EA5-4DED-8113-E732EFBC800B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CDEB06F2-3EA5-4DED-8113-E732EFBC800B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{FF15C174-6F00-4C77-AAE5-B98ACC68C17E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FF15C174-6F00-4C77-AAE5-B98ACC68C17E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FF15C174-6F00-4C77-AAE5-B98ACC68C17E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FF15C174-6F00-4C77-AAE5-B98ACC68C17E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -92,7 +86,6 @@ Global
 		{76D52EDF-7D8B-4B40-97D4-A2D25460D2A9} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{D5EA7180-0D91-414B-86A4-BB9885A26305} = {76D52EDF-7D8B-4B40-97D4-A2D25460D2A9}
 		{CDEB06F2-3EA5-4DED-8113-E732EFBC800B} = {31D6FB3A-2672-495C-9B8E-EC1B1F0E6522}
-		{FF15C174-6F00-4C77-AAE5-B98ACC68C17E} = {31D6FB3A-2672-495C-9B8E-EC1B1F0E6522}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5F55DDB9-3B7B-46C5-AB82-AB7A76A1B187}

--- a/dev/AzureKeyVaultEmulator.AppHost/AzureKeyVaultEmulator.AppHost.AppHost/Program.cs
+++ b/dev/AzureKeyVaultEmulator.AppHost/AzureKeyVaultEmulator.AppHost.AppHost/Program.cs
@@ -1,34 +1,7 @@
-using AzureKeyVaultEmulator.AppHost;
 using AzureKeyVaultEmulator.Shared.Constants.Orchestration;
-using WireMock.Server;
-
-var isWiremockTestRunning = args.GetFlag(AspireConstants.Wiremock);
 
 var builder = DistributedApplication.CreateBuilder();
 
 var keyVault = builder.AddProject<Projects.AzureKeyVaultEmulator>(AspireConstants.EmulatorServiceName);
-
-if (isWiremockTestRunning)
-{
-    var wiremockServer = WireMockServer
-        .Start(useSSL: true);
-
-    wiremockServer.Given(WireMock.RequestBuilders.Request.Create()
-        .WithPath(WiremockConstants.EndpointPath)
-        .UsingGet())
-        .RespondWith(
-             WireMock.ResponseBuilders.Response.Create()
-            .WithStatusCode(200)
-            .WithBody(WiremockConstants.ConnectivityResponse)
-        );
-
-    var webApi = builder
-        .AddProject<Projects.WebApiWithEmulator_DebugHelper>(AspireConstants.DebugHelper)
-        .WithEnvironment($"ConnectionStrings__{AspireConstants.EmulatorServiceName}", keyVault.GetEndpoint("https"))
-        .WithReference(keyVault)
-        .WaitFor(keyVault);
-
-    webApi.WithEnvironment(AspireConstants.Wiremock, wiremockServer.Url);
-}
 
 builder.Build().Run();


### PR DESCRIPTION
## Describe your changes

Reverts the test changes made in #377 due to container timeout on Action runner. Random port is defaulted to `true`, no need to create multiple containers (one for each test).

Also removed skipped WireMock tests which have caused havoc with releases in the past and skipped for months.

## Issue ticket number and link

* Fixes: #379 