### PR TITLE
"AzureKeyVaultEmulator.Aspire.Hosting" targeting net10.0 twice ?

### DIFF
--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/AzureKeyVaultEmulator.Aspire.Hosting.csproj
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/AzureKeyVaultEmulator.Aspire.Hosting.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
## Describe your changes

Saw that in recent diff in `AzureKeyVaultEmulator.Aspire.Hosting.csproj` :
```diff
-   <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+   <TargetFrameworks>net10.0;net10.0</TargetFrameworks>
```

If the package `AzureKeyVaultEmulator.Aspire.Hosting` still needs to be `net9.0` + `net10.0`
I have no idea TBH, i'm opening that one in case I missed something obvious

## Issue ticket number and link

* none, unsure if that's an issue or not

## Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] I have ran the test suite locally to ensure no breaking changes have been added.
- [ ] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [ ] I have added new tests, if applicable.