### PR TITLE
fix: RS256 signing incorrectly double-hashes digest

### DIFF
--- a/src/AzureKeyVaultEmulator/Emulator/Services/EncryptionService.cs
+++ b/src/AzureKeyVaultEmulator/Emulator/Services/EncryptionService.cs
@@ -27,7 +27,7 @@ namespace AzureKeyVaultEmulator.Emulator.Services
         {
             var bytes = data.Base64UrlDecode();
 
-            var signedBytes = key.SignData(bytes, _hashingAlgorithm, _padding);
+            var signedBytes = key.SignHash(bytes, _hashingAlgorithm, _padding);
 
             return signedBytes.Base64UrlEncode();
         }
@@ -37,7 +37,7 @@ namespace AzureKeyVaultEmulator.Emulator.Services
             var hashBytes = digest.Base64UrlDecode();
             var sigBytes = signature.Base64UrlDecode();
 
-            return key.VerifyData(hashBytes, sigBytes, _hashingAlgorithm, _padding);
+            return key.VerifyHash(hashBytes, sigBytes, _hashingAlgorithm, _padding);
         }
 
         public T DecryptFromKeyVaultJwe<T>(string jweToken)

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Keys/KeysControllerTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Keys/KeysControllerTests.cs
@@ -457,7 +457,12 @@ public sealed class KeysControllerTests(KeysTestingFixture fixture) : IClassFixt
 
         var cryptoProvider = await fixture.GetCryptographyClientAsync(key);
 
-        var digest = RequestSetup.CreateRandomBytes(64);
+        byte[] digest;
+        using (var sha = SHA256.Create())
+        {
+            var data = RequestSetup.CreateRandomBytes(128);
+            digest = sha.ComputeHash(data); // 32-byte SHA-256 digest
+        }
 
         var signAlgorithm = SignatureAlgorithm.RS256;
 


### PR DESCRIPTION
## Describe your changes
See the issue description

* Fixes: #388

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have ran the test suite locally to ensure no breaking changes have been added.
- [x] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [ ] I have added new tests, if applicable.