### PR TITLE
Certificate password stripping - Fixes #390

### DIFF
--- a/src/AzureKeyVaultEmulator/Certificates/Services/CertificateBackingService.cs
+++ b/src/AzureKeyVaultEmulator/Certificates/Services/CertificateBackingService.cs
@@ -37,7 +37,7 @@ public sealed class CertificateBackingService(
 
         var backingKey = await CreateBackingKeyAsync(certName, keySize, keyType);
 
-        var backingSecret = await CreateBackingSecretAsync(certName, contentType, certificate, certificatePassword);
+        var backingSecret = await CreateBackingSecretAsync(certName, contentType, certificate, null);
 
         return (backingKey, backingSecret);
     }

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/CertificateManagementTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/CertificateManagementTests.cs
@@ -115,6 +115,160 @@ public class CertificateManagementTests(CertificatesTestingFixture fixture) : IC
         Assert.Equal(expectedContentType, importedCertificate.Policy.ContentType);
     }
 
+    [Fact]
+    public async Task ImportingPasswordProtectedCertificateStripsPassword()
+    {
+        // Arrange: Create and import a password-protected certificate
+        var client = await fixture.GetClientAsync();
+
+        var certName = fixture.FreshlyGeneratedGuid;
+        var certPwd = fixture.FreshlyGeneratedGuid;
+
+        var x509 = CreateCertificate(certName);
+
+        var exportedFromRaw = x509.Export(X509ContentType.Pkcs12, certPwd);
+
+        var options = new ImportCertificateOptions(certName, exportedFromRaw)
+        {
+            Password = certPwd,
+        };
+
+        await client.ImportCertificateAsync(options);
+
+        // Act: DownloadCertificateAsync is a convenience method in Azure SDK that internally
+        // retrieves the backing secret (via SecretClient) and returns the full certificate with private key.
+        // This is different from GetCertificateAsync which only returns public cert + metadata.
+        var downloadedCertificateResponse = await client.DownloadCertificateAsync(certName);
+        var downloadedCertificate = downloadedCertificateResponse.Value;
+
+        // Assert: The downloaded certificate should be usable without the original password
+        // Azure Key Vault strips the password from imported certificates when storing in backing secret
+        Assert.NotNull(downloadedCertificate);
+        Assert.True(downloadedCertificate.HasPrivateKey, "DownloadCertificateAsync should return certificate with private key (from backing secret)");
+
+        // Verify private key is accessible without the original password
+        // This would fail if the password was retained in the backing secret
+        var privateKey = downloadedCertificate.GetRSAPrivateKey();
+        Assert.NotNull(privateKey);
+    }
+
+    [Fact]
+    public async Task GettingCertificateDoesNotIncludePrivateKey()
+    {
+        // Arrange: Import a certificate with private key
+        var certClient = await fixture.GetClientAsync();
+
+        var certName = fixture.FreshlyGeneratedGuid;
+        var certPwd = fixture.FreshlyGeneratedGuid;
+
+        var x509 = CreateCertificate(certName);
+
+        var exportedFromRaw = x509.Export(X509ContentType.Pkcs12, certPwd);
+
+        var importOptions = new ImportCertificateOptions(certName, exportedFromRaw)
+        {
+            Password = certPwd,
+        };
+
+        await certClient.ImportCertificateAsync(importOptions);
+
+        // Act: Get the certificate via CertificateClient (NOT SecretClient)
+        var certResponse = await certClient.GetCertificateAsync(certName);
+        var cert = certResponse.Value;
+
+        // Assert: The certificate from CertificateClient should NOT have private key
+        // Azure Key Vault's Certificates API only returns public certificate + metadata
+        // Private key is only available via SecretClient (backing secret)
+        Assert.NotNull(cert);
+        Assert.NotNull(cert.Cer);
+        Assert.NotEmpty(cert.Cer);
+
+        // Load the certificate from the Cer property (raw X.509 certificate bytes - DER encoded)
+        var loadedCert = X509CertificateLoader.LoadCertificate(cert.Cer);
+
+        Assert.NotNull(loadedCert);
+        Assert.False(loadedCert.HasPrivateKey, "Certificate from CertificateClient.GetCertificateAsync should NOT have private key");
+    }
+
+    [Fact]
+    public async Task ImportingCertificateCreatesBackingSecret()
+    {
+        // Arrange: Import a certificate
+        var certClient = await fixture.GetClientAsync();
+        var secretClient = await fixture.GetSecretClientAsync();
+
+        var certName = fixture.FreshlyGeneratedGuid;
+        var certPwd = fixture.FreshlyGeneratedGuid;
+
+        var x509 = CreateCertificate(certName);
+
+        var exportedFromRaw = x509.Export(X509ContentType.Pkcs12, certPwd);
+
+        var importOptions = new ImportCertificateOptions(certName, exportedFromRaw)
+        {
+            Password = certPwd,
+        };
+
+        // Act: Import the certificate
+        await certClient.ImportCertificateAsync(importOptions);
+
+        // Assert: A backing secret with the same name should be created
+        // Azure Key Vault automatically creates a secret with the same name as the certificate
+        // containing the full PFX (with private key) when a certificate is imported
+        var backingSecretResponse = await secretClient.GetSecretAsync(certName);
+        var backingSecret = backingSecretResponse.Value;
+
+        Assert.NotNull(backingSecret);
+        Assert.Equal(certName, backingSecret.Name);
+        Assert.NotNull(backingSecret.Value);
+        Assert.Equal("application/x-pkcs12", backingSecret.Properties.ContentType);
+    }
+
+    [Fact]
+    public async Task ImportingPasswordProtectedCertificateBackingSecretHasNoPassword()
+    {
+        // Arrange: Create and import a password-protected certificate
+        var certClient = await fixture.GetClientAsync();
+        var secretClient = await fixture.GetSecretClientAsync();
+
+        var certName = fixture.FreshlyGeneratedGuid;
+        var originalPassword = fixture.FreshlyGeneratedGuid;
+
+        var x509 = CreateCertificate(certName);
+
+        var exportedFromRaw = x509.Export(X509ContentType.Pkcs12, originalPassword);
+
+        var importOptions = new ImportCertificateOptions(certName, exportedFromRaw)
+        {
+            Password = originalPassword,
+        };
+
+        await certClient.ImportCertificateAsync(importOptions);
+
+        // Act: Get the backing secret directly via SecretClient
+        var backingSecretResponse = await secretClient.GetSecretAsync(certName);
+        var backingSecret = backingSecretResponse.Value;
+
+        // Assert: The backing secret should contain PFX data
+        Assert.NotNull(backingSecret);
+        Assert.NotNull(backingSecret.Value);
+        Assert.Equal("application/x-pkcs12", backingSecret.Properties.ContentType);
+
+        // Convert base64 secret value to bytes
+        var pfxBytes = Convert.FromBase64String(backingSecret.Value);
+
+        // Assert: Load the certificate WITHOUT any password - this proves password was stripped
+        // If the password was retained, this would throw CryptographicException
+        var loadedCert = X509CertificateLoader.LoadPkcs12(pfxBytes, null);
+
+        Assert.NotNull(loadedCert);
+        Assert.True(loadedCert.HasPrivateKey, "Certificate from backing secret should have private key");
+
+        // Verify private key is accessible without the original password
+        var privateKey = loadedCert.GetRSAPrivateKey();
+        Assert.NotNull(privateKey);
+    }
+
     private static X509Certificate2 CreateCertificate(string name)
     {
         var keySize = 2048;

--- a/test/AzureKeyVaultEmulator.IntegrationTests/SetupHelper/Fixtures/CertificatesTestingFixture.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/SetupHelper/Fixtures/CertificatesTestingFixture.cs
@@ -1,10 +1,12 @@
 ﻿using Azure.Security.KeyVault.Certificates;
+using Azure.Security.KeyVault.Secrets;
 
 namespace AzureKeyVaultEmulator.IntegrationTests.SetupHelper.Fixtures;
 
 public sealed class CertificatesTestingFixture : KeyVaultClientTestingFixture<CertificateClient>
 {
     private CertificateClient? _certClient;
+    private SecretClient? _secretClient;
 
 #pragma warning disable CA1822 // Mark members as static, instance data is required in tests
     public CertificatePolicy BasicPolicy => CertificatePolicy.Default;
@@ -32,6 +34,22 @@ public sealed class CertificatesTestingFixture : KeyVaultClientTestingFixture<Ce
         };
 
         return _certClient = new CertificateClient(setup.VaultUri, setup.Credential, options);
+    }
+
+    public async ValueTask<SecretClient> GetSecretClientAsync()
+    {
+        if (_secretClient is not null)
+            return _secretClient;
+
+        var setup = await GetClientSetupModelAsync();
+
+        var options = new SecretClientOptions
+        {
+            DisableChallengeResourceVerification = true,
+            RetryPolicy = _clientRetryPolicy
+        };
+
+        return _secretClient = new SecretClient(setup.VaultUri, setup.Credential, options);
     }
 
     public async Task<KeyVaultCertificateWithPolicy>


### PR DESCRIPTION
## Describe your changes

Certificate import was preserving the PFX password in the stored certificate, unlike real Azure Key Vault which strips it after import. This caused `GetRSAPrivateKey()` to return null and broke mTLS signing workflows.

**Fix:** Pass `null` instead of `certificatePassword` to `CreateBackingSecretAsync`:

```csharp
// Before
var backingSecret = await CreateBackingSecretAsync(certName, contentType, certificate, certificatePassword);

// After
var backingSecret = await CreateBackingSecretAsync(certName, contentType, certificate, null);
```

This matches Azure behavior where:
- Password is used only to unlock the imported PFX
- Certificate + private key are stored unencrypted
- Retrieved certificates require no password

### Why SecretClient is used for private key access

Azure Key Vault splits certificates into two separate objects:

**1. Certificates API (CertificateClient)**

| Method | Returns | Private Key? |
|--------|---------|--------------|
| `GetCertificateAsync` | Public certificate + metadata | ❌ NO |
| `DownloadCertificateAsync` | Full certificate (convenience method that internally uses backing secret) | ✅ YES |

The Certificates API is intentionally a safe, public-facing metadata plane. `GetCertificateAsync` never returns private keys.

`DownloadCertificateAsync` is an official Azure SDK convenience method on `CertificateClient` that internally retrieves the backing secret and returns the full certificate with private key.

**2. Secrets API (SecretClient)**  

When you import a PFX, Azure automatically creates:
- A **Certificate** object (public cert + metadata)
- A **Secret** object with the same name (full PFX with private key, Base64-encoded)

To retrieve the PFX with private key directly, use SecretClient:
```csharp
var secret = await secretClient.GetSecretAsync("mycert");
var pfxBytes = Convert.FromBase64String(secret.Value);
var certWithPrivateKey = X509CertificateLoader.LoadPkcs12(pfxBytes, null);
```

### Tests Added

- **`GettingCertificateDoesNotIncludePrivateKey`** - Verifies `GetCertificateAsync` does NOT include private key (matching Azure behavior)
- **`ImportingCertificateCreatesBackingSecret`** - Verifies that importing a certificate creates a backing secret via SecretClient
- **`ImportingPasswordProtectedCertificateStripsPassword`** - Verifies `DownloadCertificateAsync` returns certificate with private key accessible without password
- **`ImportingPasswordProtectedCertificateBackingSecretHasNoPassword`** - Verifies the backing secret PFX can be loaded without password via SecretClient

## Issue ticket number and link

* Fixes: https://github.com/james-gould/azure-keyvault-emulator/issues/390

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have ran the test suite locally to ensure no breaking changes have been added.
- [x] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [x] I have added new tests, if applicable.

<!-- START COPILOT CODING AGENT SUFFIX -->



<details>

<summary>Original prompt</summary>

> ## Bug: Certificate import does not strip password as Azure Key Vault does
> 
> When importing a PFX certificate into the Azure Key Vault Emulator via the `CertificateClient.ImportCertificateAsync()` API, the emulator does not strip the PFX password from the stored certificate.
> 
> In real Azure Key Vault behavior, the password is **never preserved** after import. Azure strips the password, stores only the certificate + private key material, and does not re-expose the password via the Secrets API or Certificates API.
> 
> The emulator currently retains the password in the stored object, which breaks expected compatibility and causes code that works in Azure to fail in the emulator.
> 
> ### Root Cause
> 
> In `CertificateBackingService.cs`, the `GetBackingComponentsAsync` method passes `certificatePassword` to `CreateBackingSecretAsync`, which then serializes the certificate with the password intact.
> 
> ### The Fix
> 
> In the `GetBackingComponentsAsync` method in `src/AzureKeyVaultEmulator/Certificates/Services/CertificateBackingService.cs`, change the call to `CreateBackingSecretAsync` to pass `null` instead of `certificatePassword`:
> 
> ```csharp
> // BEFORE (around line 45):
> var backingSecret = await CreateBackingSecretAsync(certName, contentType, certificate, certificatePassword);
> 
> // AFTER:
> var backingSecret = await CreateBackingSecretAsync(certName, contentType, certificate, null);
> ```
> 
> This ensures the certificate is stored **without password protection**, matching Azure Key Vault behavior where:
> 1. The password is used only to unlock the imported PFX file
> 2. Once imported, Azure discards the password completely
> 3. The certificate + private key are stored unencrypted in PFX format
> 4. When retrieved via the Secrets API, the PFX requires no password
> 5. `X509Certificate2` creation and `GetRSAPrivateKey()` work without the original password
> 
> This fix resolves issues like:
> - `GetRSAPrivateKey()` returning null
> - X509 key usage exceptions
> - "Cannot find the certificate and private key" errors
> - mTLS signing failures
> 
> ### Issue Reference
> Fixes: https://github.com/james-gould/azure-keyvault-emulator/issues/390
> 


</details>

> ## Bug: Certificate import does not strip password as Azure Key Vault does
> 
> When importing a PFX certificate into the Azure Key Vault Emulator via the `CertificateClient.ImportCertificateAsync()` API, the emulator does not strip the PFX password from the stored certificate.
> 
> In real Azure Key Vault behavior, the password is **never preserved** after import. Azure strips the password, stores only the certificate + private key material, and does not re-expose the password via the Secrets API or Certificates API.
> 
> The emulator currently retains the password in the stored object, which breaks expected compatibility and causes code that works in Azure to fail in the emulator.
> 
> ### Root Cause
> 
> In `CertificateBackingService.cs`, the `GetBackingComponentsAsync` method passes `certificatePassword` to `CreateBackingSecretAsync`, which then serializes the certificate with the password intact.
> 
> ### The Fix
> 
> In the `GetBackingComponentsAsync` method in `src/AzureKeyVaultEmulator/Certificates/Services/CertificateBackingService.cs`, change the call to `CreateBackingSecretAsync` to pass `null` instead of `certificatePassword`:
> 
> ```csharp
> // BEFORE (around line 45):
> var backingSecret = await CreateBackingSecretAsync(certName, contentType, certificate, certificatePassword);
> 
> // AFTER:
> var backingSecret = await CreateBackingSecretAsync(certName, contentType, certificate, null);
> ```
> 
> This ensures the certificate is stored **without password protection**, matching Azure Key Vault behavior where:
> 1. The password is used only to unlock the imported PFX file
> 2. Once imported, Azure discards the password completely
> 3. The certificate + private key are stored unencrypted in PFX format
> 4. When retrieved via the Secrets API, the PFX requires no password
> 5. `X509Certificate2` creation and `GetRSAPrivateKey()` work without the original password
> 
> This fix resolves issues like:
> - `GetRSAPrivateKey()` returning null
> - X509 key usage exceptions
> - "Cannot find the certificate and private key" errors
> - mTLS signing failures
> 
> ### Issue Reference
> Fixes: https://github.com/james-gould/azure-keyvault-emulator/issues/390
> 

<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.