### PR TITLE
missing $ for string interpolation

### DIFF
--- a/src/TestContainers/dotnet/Helpers/AzureKeyVaultEmulatorCertHelper.cs
+++ b/src/TestContainers/dotnet/Helpers/AzureKeyVaultEmulatorCertHelper.cs
@@ -108,7 +108,7 @@ namespace AzureKeyVaultEmulator.TestContainers.Helpers
                 var pem = shouldWritePem ? ExportToPem(pfx) : File.ReadAllText(pemPath!);
 
                 if (OperatingSystem.IsLinux() && string.IsNullOrEmpty(pem))
-                    throw new KeyVaultEmulatorException("CRT is required for a Linux host machine but was missing at path: {pfxPath}.");
+                    throw new KeyVaultEmulatorException($"CRT is required for a Linux host machine but was missing at path: {pfxPath}.");
 
                 return (pfx, pem);
 #else


### PR DESCRIPTION
## Describe your changes

Error in CI/CD shows:
```
  AzureKeyVaultEmulator.TestContainers.Exceptions.KeyVaultEmulatorException : CRT is required for a Linux host machine but was missing at path: {pfxPath}.
```

## Issue ticket number and link
No ticket was opened for this one

```diff
- throw new KeyVaultEmulatorException( "CRT .......... {pfxPath}.");
+ throw new KeyVaultEmulatorException($"CRT .......... {pfxPath}.");
```

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have ran the test suite locally to ensure no breaking changes have been added.
- [x] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [x] NOT APPLICABLE: I have added new tests, if applicable.