### PR TITLE
[Feature] Add native seeding of secrets, keys and certificates to the Aspire hosting package

### DIFF
--- a/dev/AzureKeyVaultEmulator.AppHost/AzureKeyVaultEmulator.AppHost.AppHost/Program.cs
+++ b/dev/AzureKeyVaultEmulator.AppHost/AzureKeyVaultEmulator.AppHost.AppHost/Program.cs
@@ -1,17 +1,33 @@
-//using AzureKeyVaultEmulator.Aspire.Hosting;
+using Azure.Security.KeyVault.Keys;
+using AzureKeyVaultEmulator.AppHost;
+using AzureKeyVaultEmulator.Aspire.Hosting;
 using AzureKeyVaultEmulator.Shared.Constants.Orchestration;
+using AzureKeyVaultEmulator.Shared.Utilities;
 
 var builder = DistributedApplication.CreateBuilder();
 
-var keyVault = builder
+var seedingTestRun = args.GetFlag(AspireConstants.SeedingTest);
+
+if (!seedingTestRun)
+{
+    var keyVault = builder
     .AddProject<Projects.AzureKeyVaultEmulator>(AspireConstants.EmulatorServiceName);
     //.WithEnvironment("Persist", "true");
 
-//var keyVault = builder
-//    .AddAzureKeyVault(AspireConstants.EmulatorServiceName)
-//    .RunAsEmulator(new KeyVaultEmulatorOptions { Persist = true });
+    builder.AddProject<Projects.WebApiWithEmulator_DebugHelper>("api")
+        .WithReference(keyVault);
+}
+else
+{
+    var keyVault = builder
+        .AddAzureKeyVault(AspireConstants.EmulatorServiceName)
+        .RunAsEmulator()
+        .SeedWithSecret("first", "secretValue")
+        .SeedWithCertificate("testingCert")
+        .SeedWithKey("testingKey", KeyType.Rsa);
 
-//var api = builder.AddProject<Projects.WebApiWithEmulator_DebugHelper>("api")
-//    .WithReference(keyVault);
+    //builder.AddProject<Projects.WebApiWithEmulator_DebugHelper>("api")
+    //    .WithReference(keyVault);
+}
 
 builder.Build().Run();

--- a/dev/AzureKeyVaultEmulator.AppHost/AzureKeyVaultEmulator.AppHost.AppHost/Program.cs
+++ b/dev/AzureKeyVaultEmulator.AppHost/AzureKeyVaultEmulator.AppHost.AppHost/Program.cs
@@ -22,9 +22,9 @@ else
     var keyVault = builder
         .AddAzureKeyVault(AspireConstants.EmulatorServiceName)
         .RunAsEmulator()
-        .SeedWithSecret("first", "secretValue")
-        .SeedWithCertificate("testingCert")
-        .SeedWithKey("testingKey", KeyType.Rsa);
+        .SeedWithSecret(SeedingConstants.SeededSecretName, SeedingConstants.SeededSecretValue)
+        .SeedWithCertificate(SeedingConstants.SeededCertificateName)
+        .SeedWithKey(SeedingConstants.SeededKeyName, KeyType.Rsa);
 
     //builder.AddProject<Projects.WebApiWithEmulator_DebugHelper>("api")
     //    .WithReference(keyVault);

--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/AzureKeyVaultEmulator.Aspire.Hosting.csproj
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/AzureKeyVaultEmulator.Aspire.Hosting.csproj
@@ -20,6 +20,8 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Azure.KeyVault" />
     <PackageReference Include="Aspire.Hosting.AppHost" />
+    <PackageReference Include="Azure.Security.KeyVault.Certificates" />
+    <PackageReference Include="Azure.Security.KeyVault.Keys" />
   </ItemGroup>
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="" />

--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/Helpers/AzureKeyVaultEmulatorClientHelper.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/Helpers/AzureKeyVaultEmulatorClientHelper.cs
@@ -1,4 +1,6 @@
 ﻿using Azure.Core;
+using Azure.Security.KeyVault.Certificates;
+using Azure.Security.KeyVault.Keys;
 using Azure.Security.KeyVault.Secrets;
 
 namespace AzureKeyVaultEmulator.Aspire.Hosting.Helpers;
@@ -14,6 +16,28 @@ internal static class AzureKeyVaultEmulatorClientHelper
         var credential = new EmulatedTokenCredential(uri);
 
         return new SecretClient(uri, credential, opt);
+    }
+
+    internal static CertificateClient GetCertificateClient(string vaultUri)
+    {
+        var opt = new CertificateClientOptions { DisableChallengeResourceVerification = true };
+
+        var uri = new Uri(vaultUri);
+
+        var credential = new EmulatedTokenCredential(uri);
+
+        return new CertificateClient(uri, credential, opt);
+    }
+
+    internal static KeyClient GetKeyClient(string vaultUri)
+    {
+        var opt = new KeyClientOptions { DisableChallengeResourceVerification = true };
+
+        var uri = new Uri(vaultUri);
+
+        var credential = new EmulatedTokenCredential(uri);
+
+        return new KeyClient(uri, credential, opt);
     }
 
     private class EmulatedTokenCredential(Uri vaultUri) : TokenCredential

--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorExtensions.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorExtensions.cs
@@ -1,7 +1,5 @@
 ﻿using Aspire.Hosting.Azure;
 using Azure.Security.KeyVault.Secrets;
-using Azure.Security.KeyVault.Keys;
-using Azure.Security.KeyVault.Certificates;
 using AzureKeyVaultEmulator.Aspire.Hosting.Constants;
 using AzureKeyVaultEmulator.Aspire.Hosting.Exceptions;
 using AzureKeyVaultEmulator.Aspire.Hosting.Helpers;
@@ -118,7 +116,11 @@ namespace AzureKeyVaultEmulator.Aspire.Hosting
                     {
                         var secrets = resourceEvent.ExtractSecrets();
 
-                        await MapSecretsToEmulatorAsync(emulatedResource.VaultUri, secrets);
+                        await SeedSecretsFromParametersAsync(emulatedResource.VaultUri, secrets, ct);
+
+                        await SeedSecretsFromApphostAsync(emulatedResource.VaultUri, ct);
+                        await SeedCertificatesFromAppHostAsync(emulatedResource.VaultUri, ct);
+                        await SeedKeysFromAppHostAsync(emulatedResource.VaultUri, ct);
                     })
                     .WithHttpHealthCheck("/token")
                     .WithAnnotation(new EmulatorResourceAnnotation());
@@ -207,9 +209,8 @@ namespace AzureKeyVaultEmulator.Aspire.Hosting
             return model.Resources.OfType<AzureKeyVaultSecretResource>() ?? [];
         }
 
-        private static async ValueTask MapSecretsToEmulatorAsync(
-            string vaultUri,
-            IEnumerable<AzureKeyVaultSecretResource> secrets)
+        private static async ValueTask SeedSecretsFromParametersAsync(
+            string vaultUri, IEnumerable<AzureKeyVaultSecretResource> secrets, CancellationToken ct)
         {
             ArgumentException.ThrowIfNullOrEmpty(vaultUri);
 
@@ -218,19 +219,20 @@ namespace AzureKeyVaultEmulator.Aspire.Hosting
 
             var client = AzureKeyVaultEmulatorClientHelper.GetSecretClient(vaultUri);
 
-            var tasks = secrets.Select(s => SetSecretFromParameterAsync(client, s));
+            var tasks = secrets.Select(s => SetSecretFromParameterAsync(client, s, ct));
 
             await Task.WhenAll(tasks);
         }
 
-        private static async Task SetSecretFromParameterAsync(SecretClient client, AzureKeyVaultSecretResource secretResource)
+        private static async Task SetSecretFromParameterAsync(SecretClient client,
+            AzureKeyVaultSecretResource secretResource, CancellationToken ct)
         {
             var param = secretResource.Value as ParameterResource
                 ?? throw new KeyVaultEmulatorException($"Failed to cast secret {secretResource.Name} to {typeof(ParameterResource)}");
 
             var value = await param.GetValueAsync(default);
 
-            await client.SetSecretAsync(secretResource.SecretName, value);
+            await client.SetSecretAsync(secretResource.SecretName, value, ct);
         }
 
         private class AzureKeyVaultEmulatorResource(AzureKeyVaultResource resource) : ContainerResource(resource.Name)

--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorExtensions.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using Aspire.Hosting.Azure;
 using Azure.Security.KeyVault.Secrets;
+using Azure.Security.KeyVault.Keys;
+using Azure.Security.KeyVault.Certificates;
 using AzureKeyVaultEmulator.Aspire.Hosting.Constants;
 using AzureKeyVaultEmulator.Aspire.Hosting.Exceptions;
 using AzureKeyVaultEmulator.Aspire.Hosting.Helpers;
@@ -10,6 +12,10 @@ namespace AzureKeyVaultEmulator.Aspire.Hosting
 {
     public static class KeyVaultEmulatorExtensions
     {
+        private static List<KeyVaultSecret> _seedingSecrets = new();
+        private static List<(string keyName, CreateKeyOptions options, KeyType type)> _seedingKeys = new();
+        private static List<(string certificateName, CertificatePolicy policy)> _seedingCertificates = new();
+
         /// <summary>
         /// Directly adds the AzureKeyVaultEmulator as a container instead of routing through an Azure resource.
         /// </summary>
@@ -124,6 +130,71 @@ namespace AzureKeyVaultEmulator.Aspire.Hosting
             builder.MapResourceEvents(keyVaultResourceBuilder);
 
             return builder;
+        }
+
+        /// <summary>
+        /// Adds a secret to be seeded into the specified Azure Key Vault Emulator resource at runtime.
+        /// </summary>
+        /// <remarks>This method registers the secret for seeding but does not immediately create it in
+        /// Azure Key Vault. The secret will be created when the container is running in a healthy state.</remarks>
+        /// <param name="keyVault">The resource builder for the Azure Key Vault to which the secret will be added. Cannot be null.</param>
+        /// <param name="secretName">The name of the secret to add. Cannot be null.</param>
+        /// <param name="secretValue">The value of the secret to add. Cannot be null.</param>
+        /// <returns>The same resource builder instance for the Azure Key Vault, enabling method chaining.</returns>
+        public static IResourceBuilder<AzureKeyVaultResource> SeedWithSecret(
+            this IResourceBuilder<AzureKeyVaultResource> keyVault, string secretName, string secretValue)
+        {
+            ArgumentNullException.ThrowIfNull(keyVault);
+            ArgumentNullException.ThrowIfNull(secretName);
+            ArgumentNullException.ThrowIfNull(secretValue);
+
+            var secret = new KeyVaultSecret(secretName, secretValue);
+
+            _seedingSecrets.Add(secret);
+
+            return keyVault;
+        }
+
+        /// <summary>
+        /// Adds a key to be seeded into the specified Azure Key Vault Emulator resource at runtime.
+        /// </summary>
+        /// <remarks>This method registers the specified key to be created in the Key Vault when the
+        /// resource is provisioned. It does not immediately create the key in Azure Key Vault; the key will be created
+        /// when the container is running in a healthy state.</remarks>
+        /// <param name="keyVault">The resource builder for the Azure Key Vault to which the key will be added. Cannot be null.</param>
+        /// <param name="keyName">The name of the key to seed into the Key Vault. Cannot be null.</param>
+        /// <param name="options">The options used to configure the creation of the key.</param>
+        /// <param name="keyType">The type of key to create in the Key Vault.</param>
+        /// <returns>The same resource builder instance for the Azure Key Vault, enabling method chaining.</returns>
+        public static IResourceBuilder<AzureKeyVaultResource> SeedWithKey(
+            this IResourceBuilder<AzureKeyVaultResource> keyVault, string keyName, CreateKeyOptions options, KeyType keyType)
+        {
+            ArgumentNullException.ThrowIfNull(keyVault);
+            ArgumentNullException.ThrowIfNull(keyName);
+
+            _seedingKeys.Add((keyName, options, keyType));
+
+            return keyVault;
+        }
+
+        /// <summary>
+        /// Adds a certificate to be seeded into the specified Azure Key Vault resource at runtime.
+        /// </summary>
+        /// <remarks>This method is typically used as part of a resource definition chain to ensure that
+        /// the specified certificate is created in the Key Vault when the container is running in a healthy state.</remarks>
+        /// <param name="keyVault">The resource builder for the Azure Key Vault to which the certificate will be added. Cannot be null.</param>
+        /// <param name="certificateName">The name of the certificate to seed. Cannot be null.</param>
+        /// <param name="policy">An optional certificate policy to apply when creating the certificate. If null, the default policy is used.</param>
+        /// <returns>The original resource builder for the Azure Key Vault, enabling method chaining.</returns>
+        public static IResourceBuilder<AzureKeyVaultResource> SeedWithCertificate(
+            this IResourceBuilder<AzureKeyVaultResource> keyVault, string certificateName, CertificatePolicy? policy = null)
+        {
+            ArgumentNullException.ThrowIfNull(keyVault);
+            ArgumentNullException.ThrowIfNull(certificateName);
+
+            _seedingCertificates.Add((certificateName, policy ?? CertificatePolicy.Default));
+
+            return keyVault;
         }
 
         /// <summary>

--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorExtensions.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorExtensions.cs
@@ -10,12 +10,8 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace AzureKeyVaultEmulator.Aspire.Hosting
 {
-    public static class KeyVaultEmulatorExtensions
+    public static partial class KeyVaultEmulatorExtensions
     {
-        private static List<KeyVaultSecret> _seedingSecrets = new();
-        private static List<(string keyName, CreateKeyOptions options, KeyType type)> _seedingKeys = new();
-        private static List<(string certificateName, CertificatePolicy policy)> _seedingCertificates = new();
-
         /// <summary>
         /// Directly adds the AzureKeyVaultEmulator as a container instead of routing through an Azure resource.
         /// </summary>
@@ -133,71 +129,6 @@ namespace AzureKeyVaultEmulator.Aspire.Hosting
         }
 
         /// <summary>
-        /// Adds a secret to be seeded into the specified Azure Key Vault Emulator resource at runtime.
-        /// </summary>
-        /// <remarks>This method registers the secret for seeding but does not immediately create it in
-        /// Azure Key Vault. The secret will be created when the container is running in a healthy state.</remarks>
-        /// <param name="keyVault">The resource builder for the Azure Key Vault to which the secret will be added. Cannot be null.</param>
-        /// <param name="secretName">The name of the secret to add. Cannot be null.</param>
-        /// <param name="secretValue">The value of the secret to add. Cannot be null.</param>
-        /// <returns>The same resource builder instance for the Azure Key Vault, enabling method chaining.</returns>
-        public static IResourceBuilder<AzureKeyVaultResource> SeedWithSecret(
-            this IResourceBuilder<AzureKeyVaultResource> keyVault, string secretName, string secretValue)
-        {
-            ArgumentNullException.ThrowIfNull(keyVault);
-            ArgumentNullException.ThrowIfNull(secretName);
-            ArgumentNullException.ThrowIfNull(secretValue);
-
-            var secret = new KeyVaultSecret(secretName, secretValue);
-
-            _seedingSecrets.Add(secret);
-
-            return keyVault;
-        }
-
-        /// <summary>
-        /// Adds a key to be seeded into the specified Azure Key Vault Emulator resource at runtime.
-        /// </summary>
-        /// <remarks>This method registers the specified key to be created in the Key Vault when the
-        /// resource is provisioned. It does not immediately create the key in Azure Key Vault; the key will be created
-        /// when the container is running in a healthy state.</remarks>
-        /// <param name="keyVault">The resource builder for the Azure Key Vault to which the key will be added. Cannot be null.</param>
-        /// <param name="keyName">The name of the key to seed into the Key Vault. Cannot be null.</param>
-        /// <param name="options">The options used to configure the creation of the key.</param>
-        /// <param name="keyType">The type of key to create in the Key Vault.</param>
-        /// <returns>The same resource builder instance for the Azure Key Vault, enabling method chaining.</returns>
-        public static IResourceBuilder<AzureKeyVaultResource> SeedWithKey(
-            this IResourceBuilder<AzureKeyVaultResource> keyVault, string keyName, CreateKeyOptions options, KeyType keyType)
-        {
-            ArgumentNullException.ThrowIfNull(keyVault);
-            ArgumentNullException.ThrowIfNull(keyName);
-
-            _seedingKeys.Add((keyName, options, keyType));
-
-            return keyVault;
-        }
-
-        /// <summary>
-        /// Adds a certificate to be seeded into the specified Azure Key Vault resource at runtime.
-        /// </summary>
-        /// <remarks>This method is typically used as part of a resource definition chain to ensure that
-        /// the specified certificate is created in the Key Vault when the container is running in a healthy state.</remarks>
-        /// <param name="keyVault">The resource builder for the Azure Key Vault to which the certificate will be added. Cannot be null.</param>
-        /// <param name="certificateName">The name of the certificate to seed. Cannot be null.</param>
-        /// <param name="policy">An optional certificate policy to apply when creating the certificate. If null, the default policy is used.</param>
-        /// <returns>The original resource builder for the Azure Key Vault, enabling method chaining.</returns>
-        public static IResourceBuilder<AzureKeyVaultResource> SeedWithCertificate(
-            this IResourceBuilder<AzureKeyVaultResource> keyVault, string certificateName, CertificatePolicy? policy = null)
-        {
-            ArgumentNullException.ThrowIfNull(keyVault);
-            ArgumentNullException.ThrowIfNull(certificateName);
-
-            _seedingCertificates.Add((certificateName, policy ?? CertificatePolicy.Default));
-
-            return keyVault;
-        }
-
-        /// <summary>
         /// Gets the directory for the local certificates, required to mount it into the Emulator container as a volume.
         /// </summary>
         /// <param name="options">The granular configuration of the Emulator.</param>
@@ -287,12 +218,12 @@ namespace AzureKeyVaultEmulator.Aspire.Hosting
 
             var client = AzureKeyVaultEmulatorClientHelper.GetSecretClient(vaultUri);
 
-            var tasks = secrets.Select(s => SetSecretAsync(client, s));
+            var tasks = secrets.Select(s => SetSecretFromParameterAsync(client, s));
 
             await Task.WhenAll(tasks);
         }
 
-        private static async Task SetSecretAsync(SecretClient client, AzureKeyVaultSecretResource secretResource)
+        private static async Task SetSecretFromParameterAsync(SecretClient client, AzureKeyVaultSecretResource secretResource)
         {
             var param = secretResource.Value as ParameterResource
                 ?? throw new KeyVaultEmulatorException($"Failed to cast secret {secretResource.Name} to {typeof(ParameterResource)}");

--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorSeedingExtensions.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorSeedingExtensions.cs
@@ -223,7 +223,7 @@ public static partial class KeyVaultEmulatorExtensions
 
     internal static async ValueTask SeedKeysFromAppHostAsync(string vaultUri, CancellationToken ct)
     {
-        if (_seedingKeys.Count == 0 || _seedingExistingKeys.Count == 0)
+        if (_seedingKeys.Count == 0 && _seedingExistingKeys.Count == 0)
             return;
 
         var client = AzureKeyVaultEmulatorClientHelper.GetKeyClient(vaultUri);

--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorSeedingExtensions.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorSeedingExtensions.cs
@@ -1,0 +1,160 @@
+﻿using System.Security.Cryptography.X509Certificates;
+using Aspire.Hosting.Azure;
+using Azure.Security.KeyVault.Certificates;
+using Azure.Security.KeyVault.Keys;
+using Azure.Security.KeyVault.Secrets;
+
+namespace AzureKeyVaultEmulator.Aspire.Hosting;
+
+public static partial class KeyVaultEmulatorExtensions
+{
+    private static List<KeyVaultSecret> _seedingSecrets = new();
+    private static List<(string keyName, CreateKeyOptions options, KeyType type)> _seedingKeys = new();
+
+    // New, blank x509 certs
+    private static List<(string certificateName, CertificatePolicy policy)> _seedingCertificates = new();
+
+    // existing certs from bytes
+    private static List<ImportCertificateOptions> _seedingExistingCertificates = new();
+
+    /// <summary>
+    /// Adds a secret to be seeded into the specified Azure Key Vault Emulator resource at runtime.
+    /// </summary>
+    /// <remarks>This method registers the secret for seeding but does not immediately create it in
+    /// Azure Key Vault. The secret will be created when the container is running in a healthy state.</remarks>
+    /// <param name="keyVault">The resource builder for the Azure Key Vault to which the secret will be added. Cannot be null.</param>
+    /// <param name="secretName">The name of the secret to add. Cannot be null.</param>
+    /// <param name="secretValue">The value of the secret to add. Cannot be null.</param>
+    /// <returns>The same resource builder instance for the Azure Key Vault, enabling method chaining.</returns>
+    public static IResourceBuilder<AzureKeyVaultResource> SeedWithSecret(
+        this IResourceBuilder<AzureKeyVaultResource> keyVault, string secretName, string secretValue)
+    {
+        ArgumentNullException.ThrowIfNull(keyVault);
+        ArgumentNullException.ThrowIfNull(secretName);
+        ArgumentNullException.ThrowIfNull(secretValue);
+
+        var secret = new KeyVaultSecret(secretName, secretValue);
+
+        _seedingSecrets.Add(secret);
+
+        return keyVault;
+    }
+
+    /// <summary>
+    /// Adds a key to be seeded into the specified Azure Key Vault Emulator resource at runtime.
+    /// </summary>
+    /// <remarks>This method registers the specified key to be created in the Key Vault when the
+    /// resource is provisioned. It does not immediately create the key in Azure Key Vault; the key will be created
+    /// when the container is running in a healthy state.</remarks>
+    /// <param name="keyVault">The resource builder for the Azure Key Vault to which the key will be added. Cannot be null.</param>
+    /// <param name="keyName">The name of the key to seed into the Key Vault. Cannot be null.</param>
+    /// <param name="options">The options used to configure the creation of the key.</param>
+    /// <param name="keyType">The type of key to create in the Key Vault.</param>
+    /// <returns>The same resource builder instance for the Azure Key Vault, enabling method chaining.</returns>
+    public static IResourceBuilder<AzureKeyVaultResource> SeedWithKey(
+        this IResourceBuilder<AzureKeyVaultResource> keyVault, string keyName, CreateKeyOptions options, KeyType keyType)
+    {
+        ArgumentNullException.ThrowIfNull(keyVault);
+        ArgumentNullException.ThrowIfNull(keyName);
+
+        _seedingKeys.Add((keyName, options, keyType));
+
+        return keyVault;
+    }
+
+    /// <summary>
+    /// Adds a certificate to be seeded into the specified Azure Key Vault resource at runtime.
+    /// </summary>
+    /// <remarks>This method is typically used as part of a resource definition chain to ensure that
+    /// the specified certificate is created in the Key Vault when the container is running in a healthy state.</remarks>
+    /// <param name="keyVault">The resource builder for the Azure Key Vault to which the certificate will be added. Cannot be null.</param>
+    /// <param name="certificateName">The name of the certificate to seed. Cannot be null.</param>
+    /// <param name="policy">An optional certificate policy to apply when creating the certificate. If null, the default policy is used.</param>
+    /// <returns>The original resource builder for the Azure Key Vault, enabling method chaining.</returns>
+    public static IResourceBuilder<AzureKeyVaultResource> SeedWithCertificate(
+        this IResourceBuilder<AzureKeyVaultResource> keyVault, string certificateName, CertificatePolicy? policy = null)
+    {
+        ArgumentNullException.ThrowIfNull(keyVault);
+        ArgumentNullException.ThrowIfNull(certificateName);
+
+        _seedingCertificates.Add((certificateName, policy ?? CertificatePolicy.Default));
+
+        return keyVault;
+    }
+
+    /// <summary>
+    /// Adds a certificate to the Azure Key Vault resource for seeding during initialization.
+    /// </summary>
+    /// <remarks>Use this method to pre-populate the emulator's key vault with a certificate before starting
+    /// the resource. This is useful for integration testing or local development scenarios where a known certificate is
+    /// required.</remarks>
+    /// <param name="keyVault">The resource builder for the Azure Key Vault to which the certificate will be added.</param>
+    /// <param name="certificateName">The name to assign to the certificate within the key vault. Cannot be null or empty.</param>
+    /// <param name="certificateBytes">The byte array containing the certificate data to import. Must not be null or empty.</param>
+    /// <param name="policy">An optional certificate policy to associate with the imported certificate. If null, the default policy is used.</param>
+    /// <returns>The same resource builder instance, enabling method chaining.</returns>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="certificateName"/> is null or empty, or if <paramref name="certificateBytes"/> is null
+    /// or empty.</exception>
+    public static IResourceBuilder<AzureKeyVaultResource> SeedWithCertificate(
+        this IResourceBuilder<AzureKeyVaultResource> keyVault, string certificateName,
+        byte[] certificateBytes, CertificatePolicy? policy = null)
+    {
+        ArgumentNullException.ThrowIfNull(keyVault);
+        ArgumentException.ThrowIfNullOrEmpty(certificateName);
+
+        if (certificateBytes is null || certificateBytes.Length == 0)
+            throw new ArgumentException($"Cannot seed with empty certificate, byte array was null or empty.");
+
+        var importOptions = new ImportCertificateOptions(certificateName, certificateBytes)
+        {
+            Policy = policy ?? CertificatePolicy.Default
+        };
+
+        _seedingExistingCertificates.Add(importOptions);
+
+        return keyVault;
+    }
+
+    /// <summary>
+    /// Adds a certificate to the Azure Key Vault emulator resource for seeding during initialization.
+    /// </summary>
+    /// <remarks>Use this method to pre-populate the emulator with a certificate, which can be useful for
+    /// integration testing or local development scenarios. The certificate is loaded from the specified file path and
+    /// made available in the emulator under the provided name.</remarks>
+    /// <param name="keyVault">The resource builder for the Azure Key Vault emulator to which the certificate will be added.</param>
+    /// <param name="certificateName">The name to assign to the certificate within the key vault. Cannot be null or empty.</param>
+    /// <param name="certificatePath">The file system path to the certificate file to import. Cannot be null or empty.</param>
+    /// <param name="policy">An optional certificate policy to associate with the imported certificate. If null, the default policy is used.</param>
+    /// <returns>The same resource builder instance, enabling method chaining.</returns>
+    /// <exception cref="ArgumentException">Thrown if either <paramref name="certificateName"/> or <paramref name="certificatePath"/> is null or empty, or
+    /// if the certificate file cannot be found at the specified path.</exception>
+    public static IResourceBuilder<AzureKeyVaultResource> SeedWithCertificate(
+        this IResourceBuilder<AzureKeyVaultResource> keyVault, string certificateName,
+        string certificatePath, CertificatePolicy? policy = null)
+    {
+        ArgumentNullException.ThrowIfNull(keyVault);
+        ArgumentException.ThrowIfNullOrEmpty(certificateName);
+        ArgumentException.ThrowIfNullOrEmpty(certificatePath);
+
+        var exists = File.Exists(certificatePath);
+
+        if (!exists)
+            throw new ArgumentException($"Cannot find certificate at provided path: {certificatePath}");
+
+        X509Certificate2 cert = null!;
+
+#if NET8_0
+        cert = new X509Certificate2(certificatePath);
+#elif NET9_0_OR_GREATER
+        cert = X509CertificateLoader.LoadCertificateFromFile(certificatePath);
+#endif
+
+        var bytes = cert.RawData;
+
+        var options = new ImportCertificateOptions(certificateName, bytes);
+
+        _seedingExistingCertificates.Add(options);
+
+        return keyVault;
+    }
+}

--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorSeedingExtensions.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorSeedingExtensions.cs
@@ -3,19 +3,25 @@ using Aspire.Hosting.Azure;
 using Azure.Security.KeyVault.Certificates;
 using Azure.Security.KeyVault.Keys;
 using Azure.Security.KeyVault.Secrets;
+using AzureKeyVaultEmulator.Aspire.Hosting.Helpers;
 
 namespace AzureKeyVaultEmulator.Aspire.Hosting;
 
 public static partial class KeyVaultEmulatorExtensions
 {
-    private static List<KeyVaultSecret> _seedingSecrets = new();
-    private static List<(string keyName, CreateKeyOptions options, KeyType type)> _seedingKeys = new();
+    private static readonly List<KeyVaultSecret> _seedingSecrets = [];
+
+    // New, blank keys
+    private static readonly List<(string keyName, CreateKeyOptions options, KeyType type)> _seedingKeys = [];
+
+    // Existing keys being imported
+    private static readonly List<ImportKeyOptions> _seedingExistingKeys = [];
 
     // New, blank x509 certs
-    private static List<(string certificateName, CertificatePolicy policy)> _seedingCertificates = new();
+    private static readonly List<(string certificateName, CertificatePolicy policy)> _seedingCertificates = [];
 
     // existing certs from bytes
-    private static List<ImportCertificateOptions> _seedingExistingCertificates = new();
+    private static readonly List<ImportCertificateOptions> _seedingExistingCertificates = [];
 
     /// <summary>
     /// Adds a secret to be seeded into the specified Azure Key Vault Emulator resource at runtime.
@@ -52,12 +58,38 @@ public static partial class KeyVaultEmulatorExtensions
     /// <param name="keyType">The type of key to create in the Key Vault.</param>
     /// <returns>The same resource builder instance for the Azure Key Vault, enabling method chaining.</returns>
     public static IResourceBuilder<AzureKeyVaultResource> SeedWithKey(
-        this IResourceBuilder<AzureKeyVaultResource> keyVault, string keyName, CreateKeyOptions options, KeyType keyType)
+        this IResourceBuilder<AzureKeyVaultResource> keyVault, string keyName,
+        CreateKeyOptions options, KeyType keyType)
     {
         ArgumentNullException.ThrowIfNull(keyVault);
-        ArgumentNullException.ThrowIfNull(keyName);
+        ArgumentException.ThrowIfNullOrEmpty(keyName);
 
         _seedingKeys.Add((keyName, options, keyType));
+
+        return keyVault;
+    }
+
+    /// <summary>
+    /// Adds a key to be seeded into the specified Azure Key Vault Emulator resource at runtime.
+    /// </summary>
+    /// <remarks>This method registers the specified key to be created in the Key Vault when the
+    /// resource is provisioned. It does not immediately create the key in Azure Key Vault; the key will be created
+    /// when the container is running in a healthy state.</remarks>
+    /// <param name="keyVault">The resource builder for the Azure Key Vault to which the key will be added. Cannot be null.</param>
+    /// <param name="keyName">The name of the key to seed into the Key Vault. Cannot be null.</param>
+    /// <param name="jsonWebKey">The key to import.</param>
+    /// <param name="keyType">The type of key to create in the Key Vault.</param>
+    /// <returns>The same resource builder instance for the Azure Key Vault, enabling method chaining.</returns>
+    public static IResourceBuilder<AzureKeyVaultResource> SeedWithKey(
+        this IResourceBuilder<AzureKeyVaultResource> keyVault, string keyName,
+        JsonWebKey jsonWebKey, KeyType keyType)
+    {
+        ArgumentNullException.ThrowIfNull(keyVault);
+        ArgumentException.ThrowIfNullOrEmpty(keyName);
+
+        var options = new ImportKeyOptions(keyName, jsonWebKey);
+
+        _seedingExistingKeys.Add(options);
 
         return keyVault;
     }
@@ -156,5 +188,44 @@ public static partial class KeyVaultEmulatorExtensions
         _seedingExistingCertificates.Add(options);
 
         return keyVault;
+    }
+
+    internal static async ValueTask SeedSecretsFromApphostAsync(string vaultUri, CancellationToken ct)
+    {
+        if (_seedingSecrets.Count == 0)
+            return;
+
+        var client = AzureKeyVaultEmulatorClientHelper.GetSecretClient(vaultUri);
+
+        foreach (var secret in _seedingSecrets)
+            await client.SetSecretAsync(secret, ct);
+    }
+
+    internal static async ValueTask SeedCertificatesFromAppHostAsync(string vaultUri, CancellationToken ct)
+    {
+        if (_seedingCertificates.Count == 0 || _seedingExistingCertificates.Count == 0)
+            return;
+
+        var client = AzureKeyVaultEmulatorClientHelper.GetCertificateClient(vaultUri);
+
+        foreach(var (certificateName, policy) in _seedingCertificates)
+            await client.StartCreateCertificateAsync(certificateName, policy, cancellationToken: ct);
+
+        foreach (var importOptions in _seedingExistingCertificates)
+            await client.ImportCertificateAsync(importOptions, ct);
+    }
+
+    internal static async ValueTask SeedKeysFromAppHostAsync(string vaultUri, CancellationToken ct)
+    {
+        if (_seedingKeys.Count == 0 || _seedingExistingKeys.Count == 0)
+            return;
+
+        var client = AzureKeyVaultEmulatorClientHelper.GetKeyClient(vaultUri);
+
+        foreach (var (keyName, options, type) in _seedingKeys)
+            await client.CreateKeyAsync(keyName, type, options, ct);
+
+        foreach (var options in _seedingExistingKeys)
+            await client.ImportKeyAsync(options, ct);
     }
 }

--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorSeedingExtensions.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorSeedingExtensions.cs
@@ -205,13 +205,17 @@ public static partial class KeyVaultEmulatorExtensions
 
     internal static async ValueTask SeedCertificatesFromAppHostAsync(string vaultUri, CancellationToken ct)
     {
-        if (_seedingCertificates.Count == 0 || _seedingExistingCertificates.Count == 0)
+        if (_seedingCertificates.Count == 0 && _seedingExistingCertificates.Count == 0)
             return;
 
         var client = AzureKeyVaultEmulatorClientHelper.GetCertificateClient(vaultUri);
 
         foreach(var (certificateName, policy) in _seedingCertificates)
-            await client.StartCreateCertificateAsync(certificateName, policy, cancellationToken: ct);
+        {
+            var op = await client.StartCreateCertificateAsync(certificateName, policy, cancellationToken: ct);
+
+            await op.WaitForCompletionAsync();
+        }
 
         foreach (var importOptions in _seedingExistingCertificates)
             await client.ImportCertificateAsync(importOptions, ct);

--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorSeedingExtensions.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorSeedingExtensions.cs
@@ -59,10 +59,12 @@ public static partial class KeyVaultEmulatorExtensions
     /// <returns>The same resource builder instance for the Azure Key Vault, enabling method chaining.</returns>
     public static IResourceBuilder<AzureKeyVaultResource> SeedWithKey(
         this IResourceBuilder<AzureKeyVaultResource> keyVault, string keyName,
-        CreateKeyOptions options, KeyType keyType)
+        KeyType keyType, CreateKeyOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(keyVault);
         ArgumentException.ThrowIfNullOrEmpty(keyName);
+
+        options ??= new CreateKeyOptions();
 
         _seedingKeys.Add((keyName, options, keyType));
 

--- a/src/AzureKeyVaultEmulator.Shared/Constants/Orchestration/AspireConstants.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Constants/Orchestration/AspireConstants.cs
@@ -7,4 +7,5 @@ public sealed class AspireConstants
     public const string Wiremock = "wiremock";
 
     public const string IntegrationTest = "integration";
+    public const string SeedingTest = "seeding";
 }

--- a/src/AzureKeyVaultEmulator.Shared/Constants/Orchestration/SeedingConstants.cs
+++ b/src/AzureKeyVaultEmulator.Shared/Constants/Orchestration/SeedingConstants.cs
@@ -1,0 +1,16 @@
+namespace AzureKeyVaultEmulator.Shared.Constants.Orchestration;
+
+/// <summary>
+/// Shared constants describing the resources seeded by the AppHost when the
+/// <see cref="AspireConstants.SeedingTest"/> flag is supplied. Used by both the
+/// AppHost itself and the integration tests that verify the seeded values.
+/// </summary>
+public static class SeedingConstants
+{
+    public const string SeededSecretName = "first";
+    public const string SeededSecretValue = "secretValue";
+
+    public const string SeededCertificateName = "testingCert";
+
+    public const string SeededKeyName = "testingKey";
+}

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/SeededCertificatesTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Certificates/SeededCertificatesTests.cs
@@ -1,0 +1,43 @@
+using AzureKeyVaultEmulator.IntegrationTests.Extensions;
+using AzureKeyVaultEmulator.IntegrationTests.SetupHelper.Fixtures.Seeding;
+using AzureKeyVaultEmulator.Shared.Constants.Orchestration;
+
+namespace AzureKeyVaultEmulator.IntegrationTests.Certificates;
+
+public sealed class SeededCertificatesTests(SeededCertificatesTestingFixture fixture)
+    : IClassFixture<SeededCertificatesTestingFixture>
+{
+    [Fact]
+    public async Task SeededCertificateIsAvailableInRunningEmulatorTest()
+    {
+        var client = await fixture.GetClientAsync();
+
+        var seededCert = await client.GetCertAsync(SeedingConstants.SeededCertificateName);
+
+        Assert.NotNull(seededCert);
+        Assert.Equal(SeedingConstants.SeededCertificateName, seededCert.Name);
+    }
+
+    [Fact]
+    public async Task SeededCertificateHasVersionTest()
+    {
+        var client = await fixture.GetClientAsync();
+
+        var seededCert = await client.GetCertAsync(SeedingConstants.SeededCertificateName);
+
+        Assert.NotNull(seededCert.Properties);
+        Assert.False(string.IsNullOrEmpty(seededCert.Properties.Version));
+    }
+
+    [Fact]
+    public async Task SeededCertificateWillHaveAttributesSetTest()
+    {
+        var client = await fixture.GetClientAsync();
+
+        var seededCert = await client.GetCertAsync(SeedingConstants.SeededCertificateName);
+
+        Assert.NotNull(seededCert);
+        Assert.NotNull(seededCert.Properties.RecoveryLevel);
+        Assert.NotNull(seededCert.Properties.RecoverableDays);
+    }
+}

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Keys/SeededKeysTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Keys/SeededKeysTests.cs
@@ -1,0 +1,43 @@
+using AzureKeyVaultEmulator.IntegrationTests.SetupHelper.Fixtures.Seeding;
+using AzureKeyVaultEmulator.Shared.Constants.Orchestration;
+
+namespace AzureKeyVaultEmulator.IntegrationTests.Keys;
+
+public sealed class SeededKeysTests(SeededKeysTestingFixture fixture) : IClassFixture<SeededKeysTestingFixture>
+{
+    [Fact]
+    public async Task SeededKeyIsAvailableInRunningEmulatorTest()
+    {
+        var client = await fixture.GetClientAsync();
+
+        var seededKey = await client.GetKeyAsync(SeedingConstants.SeededKeyName);
+
+        Assert.NotNull(seededKey);
+        Assert.NotNull(seededKey.Value);
+        Assert.Equal(SeedingConstants.SeededKeyName, seededKey.Value.Name);
+    }
+
+    [Fact]
+    public async Task SeededKeyHasConfiguredKeyTypeTest()
+    {
+        var client = await fixture.GetClientAsync();
+
+        var seededKey = await client.GetKeyAsync(SeedingConstants.SeededKeyName);
+
+        Assert.Equal(SeededKeysTestingFixture.SeededKeyType, seededKey.Value.KeyType);
+        Assert.Equal(SeededKeysTestingFixture.SeededKeyType, seededKey.Value.Key.KeyType);
+    }
+
+    [Fact]
+    public async Task SeededKeyWillHaveAttributesSetTest()
+    {
+        var client = await fixture.GetClientAsync();
+
+        var seededKey = await client.GetKeyAsync(SeedingConstants.SeededKeyName);
+
+        Assert.NotNull(seededKey.Value.Properties);
+        Assert.NotNull(seededKey.Value.Properties.RecoveryLevel);
+        Assert.NotNull(seededKey.Value.Properties.RecoverableDays);
+        Assert.False(string.IsNullOrEmpty(seededKey.Value.Properties.Version));
+    }
+}

--- a/test/AzureKeyVaultEmulator.IntegrationTests/Secrets/SeededSecretsTests.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/Secrets/SeededSecretsTests.cs
@@ -1,0 +1,43 @@
+using AzureKeyVaultEmulator.IntegrationTests.SetupHelper.Fixtures.Seeding;
+using AzureKeyVaultEmulator.Shared.Constants.Orchestration;
+
+namespace AzureKeyVaultEmulator.IntegrationTests.Secrets
+{
+    public class SeededSecretsTests(SeededSecretsTestingFixture fixture) : IClassFixture<SeededSecretsTestingFixture>
+    {
+        [Fact]
+        public async Task SeededSecretIsAvailableInRunningEmulatorTest()
+        {
+            var client = await fixture.GetClientAsync();
+
+            var seededSecret = await client.GetSecretAsync(SeedingConstants.SeededSecretName);
+
+            Assert.NotNull(seededSecret);
+            Assert.NotNull(seededSecret.Value);
+            Assert.Equal(SeedingConstants.SeededSecretName, seededSecret.Value.Name);
+        }
+
+        [Fact]
+        public async Task SeededSecretReturnsConfiguredValueTest()
+        {
+            var client = await fixture.GetClientAsync();
+
+            var seededSecret = await client.GetSecretAsync(SeedingConstants.SeededSecretName);
+
+            Assert.Equal(SeedingConstants.SeededSecretValue, seededSecret.Value.Value);
+        }
+
+        [Fact]
+        public async Task SeededSecretWillHaveAttributesSetTest()
+        {
+            var client = await fixture.GetClientAsync();
+
+            var seededSecret = await client.GetSecretAsync(SeedingConstants.SeededSecretName);
+
+            Assert.NotNull(seededSecret.Value.Properties);
+            Assert.NotNull(seededSecret.Value.Properties.RecoveryLevel);
+            Assert.NotNull(seededSecret.Value.Properties.RecoverableDays);
+            Assert.False(string.IsNullOrEmpty(seededSecret.Value.Properties.Version));
+        }
+    }
+}

--- a/test/AzureKeyVaultEmulator.IntegrationTests/SetupHelper/Fixtures/Seeding/SeededCertificatesTestingFixture.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/SetupHelper/Fixtures/Seeding/SeededCertificatesTestingFixture.cs
@@ -1,0 +1,24 @@
+using Azure.Security.KeyVault.Certificates;
+
+namespace AzureKeyVaultEmulator.IntegrationTests.SetupHelper.Fixtures.Seeding;
+
+public sealed class SeededCertificatesTestingFixture : SeedingTestingFixture<CertificateClient>
+{
+    private CertificateClient? _certClient;
+
+    public override async ValueTask<CertificateClient> GetClientAsync()
+    {
+        if (_certClient is not null)
+            return _certClient;
+
+        var setup = await GetClientSetupModelAsync();
+
+        var options = new CertificateClientOptions
+        {
+            DisableChallengeResourceVerification = true,
+            RetryPolicy = _clientRetryPolicy
+        };
+
+        return _certClient = new CertificateClient(setup.VaultUri, setup.Credential, options);
+    }
+}

--- a/test/AzureKeyVaultEmulator.IntegrationTests/SetupHelper/Fixtures/Seeding/SeededKeysTestingFixture.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/SetupHelper/Fixtures/Seeding/SeededKeysTestingFixture.cs
@@ -1,0 +1,30 @@
+using Azure.Security.KeyVault.Keys;
+
+namespace AzureKeyVaultEmulator.IntegrationTests.SetupHelper.Fixtures.Seeding;
+
+public sealed class SeededKeysTestingFixture : SeedingTestingFixture<KeyClient>
+{
+    /// <summary>
+    /// Mirrors the type seeded in <c>AzureKeyVaultEmulator.AppHost.Program</c> when the
+    /// <c>--seeding</c> flag is supplied to the AppHost.
+    /// </summary>
+    public static readonly KeyType SeededKeyType = KeyType.Rsa;
+
+    private KeyClient? _keyClient;
+
+    public override async ValueTask<KeyClient> GetClientAsync()
+    {
+        if (_keyClient is not null)
+            return _keyClient;
+
+        var setup = await GetClientSetupModelAsync();
+
+        var options = new KeyClientOptions
+        {
+            DisableChallengeResourceVerification = true,
+            RetryPolicy = _clientRetryPolicy
+        };
+
+        return _keyClient = new KeyClient(setup.VaultUri, setup.Credential, options);
+    }
+}

--- a/test/AzureKeyVaultEmulator.IntegrationTests/SetupHelper/Fixtures/Seeding/SeededSecretsTestingFixture.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/SetupHelper/Fixtures/Seeding/SeededSecretsTestingFixture.cs
@@ -1,0 +1,24 @@
+using Azure.Security.KeyVault.Secrets;
+
+namespace AzureKeyVaultEmulator.IntegrationTests.SetupHelper.Fixtures.Seeding;
+
+public sealed class SeededSecretsTestingFixture : SeedingTestingFixture<SecretClient>
+{
+    private SecretClient? _secretClient;
+
+    public override async ValueTask<SecretClient> GetClientAsync()
+    {
+        if (_secretClient is not null)
+            return _secretClient;
+
+        var setup = await GetClientSetupModelAsync();
+
+        var options = new SecretClientOptions
+        {
+            DisableChallengeResourceVerification = true,
+            RetryPolicy = _clientRetryPolicy
+        };
+
+        return _secretClient = new SecretClient(setup.VaultUri, setup.Credential, options);
+    }
+}

--- a/test/AzureKeyVaultEmulator.IntegrationTests/SetupHelper/Fixtures/Seeding/SeedingTestingFixture.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/SetupHelper/Fixtures/Seeding/SeedingTestingFixture.cs
@@ -5,7 +5,7 @@ using Azure.Core;
 using Azure.Core.Pipeline;
 using AzureKeyVaultEmulator.Shared.Constants.Orchestration;
 
-namespace AzureKeyVaultEmulator.IntegrationTests.SetupHelper.Fixtures;
+namespace AzureKeyVaultEmulator.IntegrationTests.SetupHelper.Fixtures.Seeding;
 
 /// <summary>
 /// <para>Stripped down counterpart to <see cref="KeyVaultClientTestingFixture{TClient}"/> used to verify

--- a/test/AzureKeyVaultEmulator.IntegrationTests/SetupHelper/Fixtures/SeedingTestingFixture.cs
+++ b/test/AzureKeyVaultEmulator.IntegrationTests/SetupHelper/Fixtures/SeedingTestingFixture.cs
@@ -1,0 +1,112 @@
+using Asp.Versioning;
+using Asp.Versioning.Http;
+using Aspire.Hosting;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using AzureKeyVaultEmulator.Shared.Constants.Orchestration;
+
+namespace AzureKeyVaultEmulator.IntegrationTests.SetupHelper.Fixtures;
+
+/// <summary>
+/// <para>Stripped down counterpart to <see cref="KeyVaultClientTestingFixture{TClient}"/> used to verify
+/// the seeding functionality exposed by the AppHost.</para>
+/// <para>Boots <see cref="Projects.AzureKeyVaultEmulator_AppHost"/> with the
+/// <c>--<see cref="AspireConstants.SeedingTest"/></c> flag so the seeding code path is taken.</para>
+/// </summary>
+/// <typeparam name="TClient">The Azure SDK client type used by the derived fixture.</typeparam>
+public abstract class SeedingTestingFixture<TClient> : IAsyncLifetime
+    where TClient : class
+{
+    internal readonly TimeSpan _waitPeriod = TimeSpan.FromSeconds(30);
+    internal DistributedApplication? _app;
+    internal ResourceNotificationService? _notificationService;
+
+    internal readonly RetryPolicy _clientRetryPolicy = new(
+        maxRetries: 5,
+        DelayStrategy.CreateExponentialDelayStrategy(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(100)));
+
+    private ClientSetupVM? _setupModel;
+
+    private HttpClient? _testingClient;
+    private string _bearerToken = string.Empty;
+
+    public abstract ValueTask<TClient> GetClientAsync();
+
+    public async Task InitializeAsync()
+    {
+        var builder = await DistributedApplicationTestingBuilder
+            .CreateAsync<Projects.AzureKeyVaultEmulator_AppHost>(
+                [$"--{AspireConstants.SeedingTest}"], (x, y) => x.DisableDashboard = true
+            );
+
+        _app = await builder.BuildAsync();
+
+        _notificationService = _app.Services.GetService<ResourceNotificationService>();
+
+        await _app.StartAsync();
+    }
+
+    public async ValueTask<HttpClient> CreateHttpClient(double version = 7.5, string applicationName = AspireConstants.EmulatorServiceName)
+    {
+        if (_testingClient is not null)
+            return _testingClient;
+
+        var opt = new ApiVersionHandler(new QueryStringApiVersionWriter(), new ApiVersion(version))
+        {
+            InnerHandler = new HttpClientHandler()
+        };
+
+        await _notificationService!.WaitForResourceHealthyAsync(applicationName).WaitAsync(_waitPeriod);
+
+        var endpoint = _app!.GetEndpoint(applicationName);
+
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        _testingClient = new HttpClient(opt)
+        {
+            BaseAddress = endpoint
+        };
+
+        return _testingClient;
+    }
+
+    internal async ValueTask<ClientSetupVM> GetClientSetupModelAsync(string applicationName = AspireConstants.EmulatorServiceName)
+    {
+        if (_setupModel is not null)
+            return _setupModel;
+
+        var vaultEndpoint = _app!.GetEndpoint(applicationName);
+
+        ArgumentNullException.ThrowIfNull(vaultEndpoint);
+
+        await _notificationService!.WaitForResourceHealthyAsync(applicationName).WaitAsync(_waitPeriod);
+
+        var emulatedBearerToken = await GetBearerTokenAsync();
+
+        var cred = new EmulatedTokenCredential(emulatedBearerToken);
+
+        return _setupModel = new ClientSetupVM(vaultEndpoint, cred);
+    }
+
+    public async ValueTask<string> GetBearerTokenAsync()
+    {
+        if (!string.IsNullOrEmpty(_bearerToken))
+            return _bearerToken;
+
+        _testingClient ??= await CreateHttpClient();
+
+        var response = await _testingClient.GetAsync("/token");
+
+        response.EnsureSuccessStatusCode();
+
+        return _bearerToken = await response.Content.ReadAsStringAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_app is not null)
+            await _app.DisposeAsync().ConfigureAwait(false);
+
+        _testingClient?.Dispose();
+    }
+}


### PR DESCRIPTION
## Describe your changes

Adds native seeding functionality with a convenient API directly into the AppHost.

### Secrets

```cs
builder.AddAzureKeyVault("keyvault")
    .RunAsEmulator()
    .SeedWithSecret("secretName", "secretValue");
```

### Keys

Any RSA key:

```cs
builder.AddAzureKeyVault("keyvault")
    .RunAsEmulator()
    .SeedWithKey("keyName", KeyType.RSA);
```

Imported, existing key:

```cs
var existingKey = new JsonWebKey(bytes);

builder.AddAzureKeyVault("keyvault")
    .RunAsEmulator()
    .SeedWithKey("secretName", existingKey);
```

### Certificates

Any `X509Certificate2` in `PKCS12` format:

```cs
builder.AddAzureKeyVault("keyvault")
    .RunAsEmulator()
    .SeedWithCertificate("certificateName");
```

An existing `X509Certificate2` in a raw `byte[]` structure:

```cs
byte[] cert = {raw data};

builder.AddAzureKeyVault("keyvault")
    .RunAsEmulator()
    .SeedWithCertificate("certificateName", cert);
```

An existing certificate from disk:

```cs
builder.AddAzureKeyVault("keyvault")
    .RunAsEmulator()
    .SeedWithCertificate("certificateName", @"C:/my/path/to/cert.pfx");
```

## Issue ticket number and link

* Fixes: #278 

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have ran the test suite locally to ensure no breaking changes have been added.
- [x] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [x] I have added new tests, if applicable.