### PR TITLE
Fix/httpclient lifetime

### DIFF
--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/Helpers/AzureKeyVaultEmulatorClientHelper.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/Helpers/AzureKeyVaultEmulatorClientHelper.cs
@@ -7,51 +7,56 @@ namespace AzureKeyVaultEmulator.Aspire.Hosting.Helpers;
 
 internal static class AzureKeyVaultEmulatorClientHelper
 {
-    internal static SecretClient GetSecretClient(string vaultUri)
+    internal const string _httpClientName = "AzureKeyVaultEmulator.Aspire.Hosting";
+
+    internal static SecretClient GetSecretClient(string vaultUri, IHttpClientFactory httpClientFactory)
     {
+        ArgumentNullException.ThrowIfNull(httpClientFactory);
+
         var opt = new SecretClientOptions { DisableChallengeResourceVerification = true };
 
         var uri = new Uri(vaultUri);
 
-        var credential = new EmulatedTokenCredential(uri);
+        var credential = new EmulatedTokenCredential(uri, httpClientFactory);
 
         return new SecretClient(uri, credential, opt);
     }
 
-    internal static CertificateClient GetCertificateClient(string vaultUri)
+    internal static CertificateClient GetCertificateClient(string vaultUri, IHttpClientFactory httpClientFactory)
     {
+        ArgumentNullException.ThrowIfNull(httpClientFactory);
+
         var opt = new CertificateClientOptions { DisableChallengeResourceVerification = true };
 
         var uri = new Uri(vaultUri);
 
-        var credential = new EmulatedTokenCredential(uri);
+        var credential = new EmulatedTokenCredential(uri, httpClientFactory);
 
         return new CertificateClient(uri, credential, opt);
     }
 
-    internal static KeyClient GetKeyClient(string vaultUri)
+    internal static KeyClient GetKeyClient(string vaultUri, IHttpClientFactory httpClientFactory)
     {
+        ArgumentNullException.ThrowIfNull(httpClientFactory);
+
         var opt = new KeyClientOptions { DisableChallengeResourceVerification = true };
 
         var uri = new Uri(vaultUri);
 
-        var credential = new EmulatedTokenCredential(uri);
+        var credential = new EmulatedTokenCredential(uri, httpClientFactory);
 
         return new KeyClient(uri, credential, opt);
     }
 
-    private class EmulatedTokenCredential(Uri vaultUri) : TokenCredential
+    private class EmulatedTokenCredential(Uri vaultUri, IHttpClientFactory httpClientFactory) : TokenCredential
     {
-        private static readonly HttpClient _httpClient = new HttpClient();
-
         public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
             => GetTokenAsync(requestContext, cancellationToken).AsTask().GetAwaiter().GetResult();
 
         public override async ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
         {
-            using (var response = await _httpClient.GetAsync(
-                new Uri(vaultUri, "token"),
-                cancellationToken))
+            var client = httpClientFactory.CreateClient(_httpClientName);
+            using (var response = await client.GetAsync(new Uri(vaultUri, "token"), cancellationToken))
             {
                 var content = await response.Content.ReadAsStringAsync();
 

--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/Helpers/AzureKeyVaultEmulatorClientHelper.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/Helpers/AzureKeyVaultEmulatorClientHelper.cs
@@ -42,30 +42,20 @@ internal static class AzureKeyVaultEmulatorClientHelper
 
     private class EmulatedTokenCredential(Uri vaultUri) : TokenCredential
     {
+        private static readonly HttpClient _httpClient = new HttpClient();
+
         public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
             => GetTokenAsync(requestContext, cancellationToken).AsTask().GetAwaiter().GetResult();
 
         public override async ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
         {
-            using var client = new HttpClient();
-
-            try
+            using (var response = await _httpClient.GetAsync(
+                new Uri(vaultUri, "token"),
+                cancellationToken))
             {
-                client.BaseAddress = vaultUri;
-
-                var response = await client.GetAsync("token");
-
                 var content = await response.Content.ReadAsStringAsync();
 
                 return new AccessToken(content, DateTimeOffset.Now.AddYears(1));
-            }
-            catch
-            {
-                throw;
-            }
-            finally
-            {
-                client?.Dispose();
             }
         }
     }

--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorExtensions.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorExtensions.cs
@@ -83,6 +83,8 @@ namespace AzureKeyVaultEmulator.Aspire.Hosting
 
             var containerTag = options.ImageTag ?? AzureKeyVaultEnvHelper.GetContainerTag();
 
+            builder.ApplicationBuilder.Services.AddHttpClient(AzureKeyVaultEmulatorClientHelper._httpClientName);
+
             var keyVaultResourceBuilder = builder.ApplicationBuilder.CreateResourceBuilder(new AzureKeyVaultEmulatorResource(builder.Resource))
                    .WithImage(KeyVaultEmulatorContainerConstants.Image)
                    .WithImageRegistry(KeyVaultEmulatorContainerConstants.Registry)
@@ -119,13 +121,14 @@ namespace AzureKeyVaultEmulator.Aspire.Hosting
                     })
                     .OnResourceReady(async (emulatedResource, resourceEvent, ct) =>
                     {
+                        var httpClientFactory = resourceEvent.Services.GetRequiredService<IHttpClientFactory>();
                         var secrets = resourceEvent.ExtractSecrets();
 
-                        await SeedSecretsFromParametersAsync(emulatedResource.VaultUri, secrets, ct);
+                        await SeedSecretsFromParametersAsync(emulatedResource.VaultUri, secrets, httpClientFactory, ct);
 
-                        await SeedSecretsFromApphostAsync(emulatedResource.VaultUri, ct);
-                        await SeedCertificatesFromAppHostAsync(emulatedResource.VaultUri, ct);
-                        await SeedKeysFromAppHostAsync(emulatedResource.VaultUri, ct);
+                        await SeedSecretsFromApphostAsync(emulatedResource.VaultUri, httpClientFactory, ct);
+                        await SeedCertificatesFromAppHostAsync(emulatedResource.VaultUri, httpClientFactory, ct);
+                        await SeedKeysFromAppHostAsync(emulatedResource.VaultUri, httpClientFactory, ct);
                     })
                     .WithHttpHealthCheck("/token")
                     .WithAnnotation(new EmulatorResourceAnnotation());
@@ -215,14 +218,18 @@ namespace AzureKeyVaultEmulator.Aspire.Hosting
         }
 
         private static async ValueTask SeedSecretsFromParametersAsync(
-            string vaultUri, IEnumerable<AzureKeyVaultSecretResource> secrets, CancellationToken ct)
+            string vaultUri,
+            IEnumerable<AzureKeyVaultSecretResource> secrets,
+            IHttpClientFactory httpClientFactory,
+            CancellationToken ct)
         {
             ArgumentException.ThrowIfNullOrEmpty(vaultUri);
+            ArgumentNullException.ThrowIfNull(httpClientFactory);
 
             if (!secrets.Any())
                 return;
 
-            var client = AzureKeyVaultEmulatorClientHelper.GetSecretClient(vaultUri);
+            var client = AzureKeyVaultEmulatorClientHelper.GetSecretClient(vaultUri, httpClientFactory);
 
             var tasks = secrets.Select(s => SetSecretFromParameterAsync(client, s, ct));
 

--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorSeedingExtensions.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/KeyVaultEmulatorSeedingExtensions.cs
@@ -192,23 +192,33 @@ public static partial class KeyVaultEmulatorExtensions
         return keyVault;
     }
 
-    internal static async ValueTask SeedSecretsFromApphostAsync(string vaultUri, CancellationToken ct)
+    internal static async ValueTask SeedSecretsFromApphostAsync(
+        string vaultUri,
+        IHttpClientFactory httpClientFactory,
+        CancellationToken ct)
     {
+        ArgumentNullException.ThrowIfNull(httpClientFactory);
+
         if (_seedingSecrets.Count == 0)
             return;
 
-        var client = AzureKeyVaultEmulatorClientHelper.GetSecretClient(vaultUri);
+        var client = AzureKeyVaultEmulatorClientHelper.GetSecretClient(vaultUri, httpClientFactory);
 
         foreach (var secret in _seedingSecrets)
             await client.SetSecretAsync(secret, ct);
     }
 
-    internal static async ValueTask SeedCertificatesFromAppHostAsync(string vaultUri, CancellationToken ct)
+    internal static async ValueTask SeedCertificatesFromAppHostAsync(
+        string vaultUri,
+        IHttpClientFactory httpClientFactory,
+        CancellationToken ct)
     {
+        ArgumentNullException.ThrowIfNull(httpClientFactory);
+
         if (_seedingCertificates.Count == 0 && _seedingExistingCertificates.Count == 0)
             return;
 
-        var client = AzureKeyVaultEmulatorClientHelper.GetCertificateClient(vaultUri);
+        var client = AzureKeyVaultEmulatorClientHelper.GetCertificateClient(vaultUri, httpClientFactory);
 
         foreach(var (certificateName, policy) in _seedingCertificates)
         {
@@ -221,12 +231,17 @@ public static partial class KeyVaultEmulatorExtensions
             await client.ImportCertificateAsync(importOptions, ct);
     }
 
-    internal static async ValueTask SeedKeysFromAppHostAsync(string vaultUri, CancellationToken ct)
+    internal static async ValueTask SeedKeysFromAppHostAsync(
+        string vaultUri,
+        IHttpClientFactory httpClientFactory,
+        CancellationToken ct)
     {
+        ArgumentNullException.ThrowIfNull(httpClientFactory);
+
         if (_seedingKeys.Count == 0 && _seedingExistingKeys.Count == 0)
             return;
 
-        var client = AzureKeyVaultEmulatorClientHelper.GetKeyClient(vaultUri);
+        var client = AzureKeyVaultEmulatorClientHelper.GetKeyClient(vaultUri, httpClientFactory);
 
         foreach (var (keyName, options, type) in _seedingKeys)
             await client.CreateKeyAsync(keyName, type, options, ct);

--- a/src/AzureKeyVaultEmulator.Client/EmulatedTokenCredential.cs
+++ b/src/AzureKeyVaultEmulator.Client/EmulatedTokenCredential.cs
@@ -14,6 +14,8 @@ namespace AzureKeyVaultEmulator.Aspire.Client
     [Obsolete("EmulatedTokenCredential is no longer required. The emulator now exposes an Entra-compatible OAuth2 surface, so use Azure.Identity.DefaultAzureCredential (with DefaultAzureCredentialOptions { DisableInstanceDiscovery = true }) instead. This type will be removed in a future major version.")]
     public sealed class EmulatedTokenCredential : TokenCredential
     {
+        private static readonly HttpClient _httpClient = new HttpClient();
+
         public EmulatedTokenCredential(string vaultUri)
         {
             _emulatedVaultUri = vaultUri;
@@ -26,19 +28,19 @@ namespace AzureKeyVaultEmulator.Aspire.Client
         public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
         {
             // Hate this but someone somewhere will be using Sync methods...
-            var token = GetBearerToken().GetAwaiter().GetResult();
+            var token = GetBearerToken(cancellationToken).GetAwaiter().GetResult();
 
             return new AccessToken(token, _expiry);
         }
 
         public override async ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
         {
-            var token = await GetBearerToken();
+            var token = await GetBearerToken(cancellationToken);
 
             return new AccessToken(token, _expiry);
         }
 
-        private async ValueTask<string> GetBearerToken()
+        private async ValueTask<string> GetBearerToken(CancellationToken cancellationToken)
         {
             if (!string.IsNullOrEmpty(_token))
                 return _token;
@@ -46,21 +48,13 @@ namespace AzureKeyVaultEmulator.Aspire.Client
             if (string.IsNullOrEmpty(_emulatedVaultUri))
                 throw new ArgumentNullException(nameof(_emulatedVaultUri));
 
-            HttpClient client = null;
-
-            try
+            using (var response = await _httpClient.GetAsync(
+                new Uri(new Uri(_emulatedVaultUri), "token"),
+                cancellationToken))
             {
-                client = new HttpClient();
-
-                var response = await client.GetAsync($"{_emulatedVaultUri}/token");
-
                 response.EnsureSuccessStatusCode();
 
                 return _token = await response.Content.ReadAsStringAsync();
-            }
-            finally
-            {
-                client?.Dispose();
             }
         }
     }

--- a/src/TestContainers/dotnet/Models/EmulatedTokenCredential.cs
+++ b/src/TestContainers/dotnet/Models/EmulatedTokenCredential.cs
@@ -8,6 +8,8 @@ namespace AzureKeyVaultEmulator.TestContainers.Models
 {
     public sealed class EmulatedTokenCredential : TokenCredential
     {
+        private static readonly HttpClient _httpClient = new HttpClient();
+
         public EmulatedTokenCredential(string vaultUri)
         {
             _emulatedVaultUri = vaultUri;
@@ -20,14 +22,14 @@ namespace AzureKeyVaultEmulator.TestContainers.Models
         public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
         {
             // Hate this but someone somewhere will be using Sync methods...
-            var token = GetBearerToken().GetAwaiter().GetResult();
+            var token = GetBearerToken(cancellationToken).GetAwaiter().GetResult();
 
             return new AccessToken(token, _expiry);
         }
 
         public override async ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
         {
-            var token = await GetBearerToken();
+            var token = await GetBearerToken(cancellationToken);
 
             return new AccessToken(token, _expiry);
         }
@@ -36,7 +38,7 @@ namespace AzureKeyVaultEmulator.TestContainers.Models
         /// Worth revisiting this as a typed client or similar, the wiring is a nightmare.
         /// Alternatively we could attempt to patch this in using Aspire events, requires research.
         /// </summary>
-        private async ValueTask<string> GetBearerToken()
+        private async ValueTask<string> GetBearerToken(CancellationToken cancellationToken)
         {
             if (!string.IsNullOrEmpty(_token))
                 return _token;
@@ -44,25 +46,13 @@ namespace AzureKeyVaultEmulator.TestContainers.Models
             if (string.IsNullOrEmpty(_emulatedVaultUri))
                 throw new ArgumentNullException(nameof(_emulatedVaultUri));
 
-            HttpClient? client = null;
-
-            try
+            using (var response = await _httpClient.GetAsync(
+                new Uri(new Uri(_emulatedVaultUri), "token"),
+                cancellationToken))
             {
-                client = new HttpClient();
-
-                var response = await client.GetAsync($"{_emulatedVaultUri}/token");
-
                 response.EnsureSuccessStatusCode();
 
                 return _token = await response.Content.ReadAsStringAsync();
-            }
-            catch
-            {
-                throw;
-            }
-            finally
-            {
-                client?.Dispose();
             }
         }
     }


### PR DESCRIPTION
## Describe your changes


The main change is to inject and reuse `IHttpClientFactory` for all emulator client operations, rather than creating new `HttpClient` instances on each call. This also updates all related seeding and credential logic to support this pattern.

Key changes include:

### Dependency Injection & HTTP Client Management

* Updated `AzureKeyVaultEmulatorClientHelper` to require an `IHttpClientFactory` for creating `SecretClient`, `CertificateClient`, and `KeyClient`, and modified the internal `EmulatedTokenCredential` class to use the factory instead of a new `HttpClient` per request. This ensures better HTTP connection management and aligns with best practices.
* Registered a named HTTP client (`AzureKeyVaultEmulator.Aspire.Hosting`) with the service collection during emulator setup, ensuring consistent client configuration.

### Seeding and Resource Initialization

* Modified all seeding methods (`SeedSecretsFromParametersAsync`, `SeedSecretsFromApphostAsync`, `SeedCertificatesFromAppHostAsync`, `SeedKeysFromAppHostAsync`) to accept and use `IHttpClientFactory`, ensuring that all resource initialization uses the shared client infrastructure.

### Client Credential Classes

* Updated the `EmulatedTokenCredential` implementations in both the client and test containers projects to use a static shared `HttpClient` and to accept cancellation tokens, improving efficiency and responsiveness to cancellation.

## Issue ticket number and link

* Fixes: #455 

## Checklist before requesting a review
- [X] I have performed a self-review of my code.
- [X] I have ran the test suite locally to ensure no breaking changes have been added.
- [X] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [ ] I have added new tests, if applicable.