### PR TITLE
fix(image): Bump Container Image Version

### DIFF
--- a/src/AzureKeyVaultEmulator.Aspire.Hosting/Constants/KeyVaultEmulatorContainerConstants.cs
+++ b/src/AzureKeyVaultEmulator.Aspire.Hosting/Constants/KeyVaultEmulatorContainerConstants.cs
@@ -8,7 +8,7 @@ internal partial class KeyVaultEmulatorContainerConstants
     public const string Image = "jamesgoulddev/azure-keyvault-emulator";
     public const int Port = 4997;
 
-    public const string Tag = "3.0.1";
+    public const string Tag = "3.1.0";
     public static string ArmTag => $"{Tag}-arm";
 
 }

--- a/src/TestContainers/dotnet/Constants/AzureKeyVaultEmulatorContainerConstants.cs
+++ b/src/TestContainers/dotnet/Constants/AzureKeyVaultEmulatorContainerConstants.cs
@@ -8,7 +8,7 @@ namespace AzureKeyVaultEmulator.TestContainers.Constants
         public const string Image = "jamesgoulddev/azure-keyvault-emulator";
         public const int Port = 4997;
 
-        public const string Tag = "3.0.1";
+        public const string Tag = "3.1.0";
         public static string ArmTag => $"{Tag}-arm";
     }
 


### PR DESCRIPTION
## Describe your changes

Bump Azure Key Vault Emulator image version to 3.1.0.

This updates the default container image tag used by the Aspire hosting integration.

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have ran the test suite locally to ensure no breaking changes have been added.
- [x] I have not removed or changed Azure Key Vault endpoints which break SDK functionality.
- [x] I have added new tests, if applicable.